### PR TITLE
PooledConfig default values and environment variables override values

### DIFF
--- a/engine/config_test.go
+++ b/engine/config_test.go
@@ -1,0 +1,38 @@
+package engine
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"strconv"
+	"testing"
+)
+
+//TestNewPooledConfigOk
+func TestNewPooledConfigDefault(t *testing.T) {
+	pooledConfig := NewPooledConfig()
+
+	// assert Success
+	assert.Equal(t, RUNNER_WORKERS_DEFAULT, pooledConfig.NumWorkers)
+	assert.Equal(t, RUNNER_QUEUE_SIZE_DEFAULT, pooledConfig.WorkQueueSize)
+}
+
+//TestNewPooledConfigOk
+func TestNewPooledConfigOverride(t *testing.T) {
+	previousWorkers := os.Getenv(RUNNER_WORKERS_KEY)
+	defer os.Setenv(RUNNER_WORKERS_KEY, previousWorkers)
+	previousQueue := os.Getenv(RUNNER_QUEUE_SIZE_KEY)
+	defer os.Setenv(RUNNER_QUEUE_SIZE_KEY, previousQueue)
+
+	newWorkersValue := 6
+	newQueueValue := 60
+
+	// Change values
+	os.Setenv(RUNNER_WORKERS_KEY, strconv.Itoa(newWorkersValue))
+	os.Setenv(RUNNER_QUEUE_SIZE_KEY, strconv.Itoa(newQueueValue))
+
+	pooledConfig := NewPooledConfig()
+
+	// assert Success
+	assert.Equal(t, newWorkersValue, pooledConfig.NumWorkers)
+	assert.Equal(t, newQueueValue, pooledConfig.WorkQueueSize)
+}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -28,6 +28,7 @@ func NewEngine(engineConfig *Config, triggersConfig *TriggersConfig) *Engine {
 	var engine Engine
 	engine.generator, _ = util.NewGenerator()
 	engine.engineConfig = engineConfig
+
 	engine.triggersConfig = triggersConfig
 	engine.serviceManager = util.NewServiceManager()
 

--- a/flow/flowdef/definition.go
+++ b/flow/flowdef/definition.go
@@ -19,7 +19,7 @@ type Definition struct {
 	rootTask      *Task
 	ehTask        *Task
 
-	attrs       map[string]*data.Attribute
+	attrs map[string]*data.Attribute
 
 	inputMapper *data.Mapper
 	links       map[int]*Link
@@ -44,7 +44,7 @@ func (pd *Definition) RootTask() *Task {
 }
 
 func (pd *Definition) ExplicitReply() bool {
-	return pd.explicitReply;
+	return pd.explicitReply
 }
 
 // ErrorHandler returns the error handler task of the definition
@@ -103,15 +103,15 @@ type Task struct {
 	links        []*Link
 	isScope      bool
 
-	definition   *Definition
-	parent       *Task
-	attrs        map[string]*data.Attribute
+	definition *Definition
+	parent     *Task
+	attrs      map[string]*data.Attribute
 
 	inputMapper  *data.Mapper
 	outputMapper *data.Mapper
 
-	toLinks      []*Link
-	fromLinks    []*Link
+	toLinks   []*Link
+	fromLinks []*Link
 }
 
 // ID gets the id of the task
@@ -211,12 +211,12 @@ const (
 // Link is the object that describes the definition of
 // a link.
 type Link struct {
-	id         int
-	name       string
-	fromTask   *Task
-	toTask     *Task
-	linkType   LinkType
-	value      string //expression or label
+	id       int
+	name     string
+	fromTask *Task
+	toTask   *Task
+	linkType LinkType
+	value    string //expression or label
 
 	definition *Definition
 	parent     *Task


### PR DESCRIPTION
First of a set of Iterative changes to decompose config.json

PooledConfig object now is not read from config.json, default values are used instead.

Environment variables RUNNER_WORKERS and RUNNER_QUEUE_SIZE are used to override the default values