### PR TITLE
Common library for Engine/Triggers/Activities logs

### DIFF
--- a/logger/logfactory.go
+++ b/logger/logfactory.go
@@ -48,7 +48,7 @@ func getLevel(level logrus.Level) string {
 	return "UNKNOWN"
 }
 
-// Debugf logs message at Debug level.
+// Debug logs message at Debug level.
 func (logger *FlogoLogger) Debug(args ...interface{}) {
 	logger.loggerImpl.Debug(args)
 }
@@ -58,7 +58,7 @@ func (logger *FlogoLogger) DebugEnabled() bool {
 	return logger.loggerImpl.Level >= logrus.DebugLevel
 }
 
-// Infof logs message at Info level.
+// Info logs message at Info level.
 func (logger *FlogoLogger) Info(args ...interface{}) {
 	logger.loggerImpl.Info(args)
 }
@@ -68,7 +68,7 @@ func (logger *FlogoLogger) InfoEnabled() bool {
 	return logger.loggerImpl.Level >= logrus.InfoLevel
 }
 
-// Warnf logs message at Warning level.
+// Warn logs message at Warning level.
 func (logger *FlogoLogger) Warn(args ...interface{}) {
 	logger.loggerImpl.Warn(args)
 }
@@ -78,7 +78,7 @@ func (logger *FlogoLogger) WarnEnabled() bool {
 	return logger.loggerImpl.Level >= logrus.WarnLevel
 }
 
-// Errorf logs message at Error level.
+// Error logs message at Error level.
 func (logger *FlogoLogger) Error(args ...interface{}) {
 	logger.loggerImpl.Error(args)
 }

--- a/logger/logfactory.go
+++ b/logger/logfactory.go
@@ -1,0 +1,121 @@
+package logger
+
+import (
+	"fmt"
+	"github.com/Sirupsen/logrus"
+	"strings"
+)
+
+var loggerMap = make(map[string]interface{})
+
+type FlogoLogFactory struct {
+}
+
+func init() {
+	RegisterLoggerFactory(&FlogoLogFactory{})
+}
+
+type FlogoLogger struct {
+	loggerName string
+	loggerImpl *logrus.Logger
+}
+
+type FlogoFormatter struct {
+	loggerName string
+}
+
+func (f *FlogoFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	logEntry := fmt.Sprintf("%s %-6s [%s] - %s\n", entry.Time.Format("2006-01-02 15:04:05.000000"), getLevel(entry.Level), f.loggerName, strings.TrimPrefix(strings.TrimSuffix(entry.Message, "]"), "["))
+	return []byte(logEntry), nil
+}
+
+func getLevel(level logrus.Level) string {
+	switch level {
+	case logrus.DebugLevel:
+		return "DEBUG"
+	case logrus.InfoLevel:
+		return "INFO"
+	case logrus.ErrorLevel:
+		return "ERROR"
+	case logrus.WarnLevel:
+		return "WARN"
+	case logrus.PanicLevel:
+		return "PANIC"
+	case logrus.FatalLevel:
+		return "FATAL"
+	}
+
+	return "UNKNOWN"
+}
+
+// Debugf logs message at Debug level.
+func (logger *FlogoLogger) Debug(args ...interface{}) {
+	logger.loggerImpl.Debug(args)
+}
+
+// DebugEnabled checks if Debug level is enabled.
+func (logger *FlogoLogger) DebugEnabled() bool {
+	return logger.loggerImpl.Level >= logrus.DebugLevel
+}
+
+// Infof logs message at Info level.
+func (logger *FlogoLogger) Info(args ...interface{}) {
+	logger.loggerImpl.Info(args)
+}
+
+// InfoEnabled checks if Info level is enabled.
+func (logger *FlogoLogger) InfoEnabled() bool {
+	return logger.loggerImpl.Level >= logrus.InfoLevel
+}
+
+// Warnf logs message at Warning level.
+func (logger *FlogoLogger) Warn(args ...interface{}) {
+	logger.loggerImpl.Warn(args)
+}
+
+// WarnEnabled checks if Warning level is enabled.
+func (logger *FlogoLogger) WarnEnabled() bool {
+	return logger.loggerImpl.Level >= logrus.WarnLevel
+}
+
+// Errorf logs message at Error level.
+func (logger *FlogoLogger) Error(args ...interface{}) {
+	logger.loggerImpl.Error(args)
+}
+
+// ErrorEnabled checks if Error level is enabled.
+func (logger *FlogoLogger) ErrorEnabled() bool {
+	return logger.loggerImpl.Level >= logrus.ErrorLevel
+}
+
+//SetLog Level
+func (logger *FlogoLogger) SetLogLevel(logLevel Level) {
+	switch logLevel {
+	case Debug:
+		logger.loggerImpl.Level = logrus.DebugLevel
+	case Info:
+		logger.loggerImpl.Level = logrus.InfoLevel
+	case Error:
+		logger.loggerImpl.Level = logrus.ErrorLevel
+	case Warn:
+		logger.loggerImpl.Level = logrus.WarnLevel
+	default:
+		logger.loggerImpl.Level = logrus.ErrorLevel
+	}
+}
+
+func (logfactory *FlogoLogFactory) GetLogger(name string) (Logger, error) {
+	logger := loggerMap[name]
+	if logger == nil {
+		logImpl := logrus.New()
+		logImpl.Formatter = &FlogoFormatter{
+			loggerName: name,
+		}
+		logger = &FlogoLogger{
+			loggerName: name,
+			loggerImpl: logImpl,
+		}
+		loggerMap[name] = logger
+	}
+	return logger.(Logger), nil
+}

--- a/logger/logfactory.go
+++ b/logger/logfactory.go
@@ -8,23 +8,23 @@ import (
 
 var loggerMap = make(map[string]interface{})
 
-type FlogoLogFactory struct {
+type DefaultLoggerFactory struct {
 }
 
 func init() {
-	RegisterLoggerFactory(&FlogoLogFactory{})
+	RegisterLoggerFactory(&DefaultLoggerFactory{})
 }
 
-type FlogoLogger struct {
+type DefaultLogger struct {
 	loggerName string
 	loggerImpl *logrus.Logger
 }
 
-type FlogoFormatter struct {
+type LogFormatter struct {
 	loggerName string
 }
 
-func (f *FlogoFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+func (f *LogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	logEntry := fmt.Sprintf("%s %-6s [%s] - %s\n", entry.Time.Format("2006-01-02 15:04:05.000000"), getLevel(entry.Level), f.loggerName, strings.TrimPrefix(strings.TrimSuffix(entry.Message, "]"), "["))
 	return []byte(logEntry), nil
 }
@@ -49,47 +49,47 @@ func getLevel(level logrus.Level) string {
 }
 
 // Debug logs message at Debug level.
-func (logger *FlogoLogger) Debug(args ...interface{}) {
+func (logger *DefaultLogger) Debug(args ...interface{}) {
 	logger.loggerImpl.Debug(args)
 }
 
 // DebugEnabled checks if Debug level is enabled.
-func (logger *FlogoLogger) DebugEnabled() bool {
+func (logger *DefaultLogger) DebugEnabled() bool {
 	return logger.loggerImpl.Level >= logrus.DebugLevel
 }
 
 // Info logs message at Info level.
-func (logger *FlogoLogger) Info(args ...interface{}) {
+func (logger *DefaultLogger) Info(args ...interface{}) {
 	logger.loggerImpl.Info(args)
 }
 
 // InfoEnabled checks if Info level is enabled.
-func (logger *FlogoLogger) InfoEnabled() bool {
+func (logger *DefaultLogger) InfoEnabled() bool {
 	return logger.loggerImpl.Level >= logrus.InfoLevel
 }
 
 // Warn logs message at Warning level.
-func (logger *FlogoLogger) Warn(args ...interface{}) {
+func (logger *DefaultLogger) Warn(args ...interface{}) {
 	logger.loggerImpl.Warn(args)
 }
 
 // WarnEnabled checks if Warning level is enabled.
-func (logger *FlogoLogger) WarnEnabled() bool {
+func (logger *DefaultLogger) WarnEnabled() bool {
 	return logger.loggerImpl.Level >= logrus.WarnLevel
 }
 
 // Error logs message at Error level.
-func (logger *FlogoLogger) Error(args ...interface{}) {
+func (logger *DefaultLogger) Error(args ...interface{}) {
 	logger.loggerImpl.Error(args)
 }
 
 // ErrorEnabled checks if Error level is enabled.
-func (logger *FlogoLogger) ErrorEnabled() bool {
+func (logger *DefaultLogger) ErrorEnabled() bool {
 	return logger.loggerImpl.Level >= logrus.ErrorLevel
 }
 
 //SetLog Level
-func (logger *FlogoLogger) SetLogLevel(logLevel Level) {
+func (logger *DefaultLogger) SetLogLevel(logLevel Level) {
 	switch logLevel {
 	case Debug:
 		logger.loggerImpl.Level = logrus.DebugLevel
@@ -104,14 +104,14 @@ func (logger *FlogoLogger) SetLogLevel(logLevel Level) {
 	}
 }
 
-func (logfactory *FlogoLogFactory) GetLogger(name string) (Logger, error) {
+func (logfactory *DefaultLoggerFactory) GetLogger(name string) (Logger, error) {
 	logger := loggerMap[name]
 	if logger == nil {
 		logImpl := logrus.New()
-		logImpl.Formatter = &FlogoFormatter{
+		logImpl.Formatter = &LogFormatter{
 			loggerName: name,
 		}
-		logger = &FlogoLogger{
+		logger = &DefaultLogger{
 			loggerName: name,
 			loggerImpl: logImpl,
 		}

--- a/logger/logfactory.go
+++ b/logger/logfactory.go
@@ -3,7 +3,6 @@ package logger
 import (
 	"fmt"
 	"github.com/Sirupsen/logrus"
-	"strings"
 )
 
 var loggerMap = make(map[string]interface{})
@@ -25,7 +24,7 @@ type LogFormatter struct {
 }
 
 func (f *LogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-	logEntry := fmt.Sprintf("%s %-6s [%s] - %s\n", entry.Time.Format("2006-01-02 15:04:05.000000"), getLevel(entry.Level), f.loggerName, strings.TrimPrefix(strings.TrimSuffix(entry.Message, "]"), "["))
+	logEntry := fmt.Sprintf("%s %-6s [%s] - %s\n", entry.Time.Format("2006-01-02 15:04:05.000000"), getLevel(entry.Level), f.loggerName, entry.Message)
 	return []byte(logEntry), nil
 }
 
@@ -50,7 +49,7 @@ func getLevel(level logrus.Level) string {
 
 // Debug logs message at Debug level.
 func (logger *DefaultLogger) Debug(args ...interface{}) {
-	logger.loggerImpl.Debug(args)
+	logger.loggerImpl.Debug(args...)
 }
 
 // DebugEnabled checks if Debug level is enabled.
@@ -60,7 +59,7 @@ func (logger *DefaultLogger) DebugEnabled() bool {
 
 // Info logs message at Info level.
 func (logger *DefaultLogger) Info(args ...interface{}) {
-	logger.loggerImpl.Info(args)
+	logger.loggerImpl.Info(args...)
 }
 
 // InfoEnabled checks if Info level is enabled.
@@ -70,7 +69,7 @@ func (logger *DefaultLogger) InfoEnabled() bool {
 
 // Warn logs message at Warning level.
 func (logger *DefaultLogger) Warn(args ...interface{}) {
-	logger.loggerImpl.Warn(args)
+	logger.loggerImpl.Warn(args...)
 }
 
 // WarnEnabled checks if Warning level is enabled.
@@ -80,12 +79,32 @@ func (logger *DefaultLogger) WarnEnabled() bool {
 
 // Error logs message at Error level.
 func (logger *DefaultLogger) Error(args ...interface{}) {
-	logger.loggerImpl.Error(args)
+	logger.loggerImpl.Error(args...)
 }
 
 // ErrorEnabled checks if Error level is enabled.
 func (logger *DefaultLogger) ErrorEnabled() bool {
 	return logger.loggerImpl.Level >= logrus.ErrorLevel
+}
+
+// Debug logs message at Debug level.
+func (logger *DefaultLogger) Debugf(format string, args ...interface{}) {
+	logger.loggerImpl.Debugf(format, args...)
+}
+
+// Info logs message at Info level.
+func (logger *DefaultLogger) Infof(format string, args ...interface{}) {
+	logger.loggerImpl.Infof(format, args...)
+}
+
+// Warn logs message at Warning level.
+func (logger *DefaultLogger) Warnf(format string, args ...interface{}) {
+	logger.loggerImpl.Warnf(format, args...)
+}
+
+// Error logs message at Error level.
+func (logger *DefaultLogger) Errorf(format string, args ...interface{}) {
+	logger.loggerImpl.Errorf(format, args...)
 }
 
 //SetLog Level

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -3,14 +3,14 @@ package logger
 import "errors"
 
 type Logger interface {
-	Debug(...interface{})
-	DebugEnabled() bool
-	Info(...interface{})
-	InfoEnabled() bool
-	Warn(...interface{})
-	WarnEnabled() bool
-	Error(...interface{})
-	ErrorEnabled() bool
+	Debug(agrs ...interface{})
+    Debugf(format string, args ...interface{})
+    Info(agrs ...interface{})
+    Infof(format string, args ...interface{})
+    Warn(agrs ...interface{})
+    Warnf(format string, args ...interface{})
+    Error(agrs ...interface{})
+    Errorf(format string, args ...interface{})
 	SetLogLevel(Level)
 }
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,108 @@
+package logger
+
+import (
+	"github.com/goburrow/gol"
+)
+
+type Logger interface {
+	Trace(string)
+	TraceEnabled() bool
+	Debug(string)
+	DebugEnabled() bool
+	Info(string)
+	InfoEnabled() bool
+	Warn(string)
+	WarnEnabled() bool
+	Error(string)
+	ErrorEnabled() bool
+	SetLogLevel(Level)
+}
+type Level int
+
+const (
+	Trace Level = iota
+	Debug
+	Info
+	Warn
+	Error
+)
+
+type FlogoLogger struct {
+	loggerName string
+	loggerImpl gol.Logger
+}
+
+func (logger *FlogoLogger) Trace(message string) {
+	logger.loggerImpl.Tracef(message)
+}
+
+// TraceEnabled checks if Trace level is enabled.
+func (logger *FlogoLogger) TraceEnabled() bool {
+	return logger.loggerImpl.TraceEnabled()
+}
+
+// Debugf logs message at Debug level.
+func (logger *FlogoLogger) Debug(message string) {
+	logger.loggerImpl.Debugf(message)
+}
+
+// DebugEnabled checks if Debug level is enabled.
+func (logger *FlogoLogger) DebugEnabled() bool {
+	return logger.loggerImpl.DebugEnabled()
+}
+
+// Infof logs message at Info level.
+func (logger *FlogoLogger) Info(message string) {
+	logger.loggerImpl.Infof(message)
+}
+
+// InfoEnabled checks if Info level is enabled.
+func (logger *FlogoLogger) InfoEnabled() bool {
+	return logger.loggerImpl.InfoEnabled()
+}
+
+// Warnf logs message at Warning level.
+func (logger *FlogoLogger) Warn(message string) {
+	logger.loggerImpl.Warnf(message)
+}
+
+// WarnEnabled checks if Warning level is enabled.
+func (logger *FlogoLogger) WarnEnabled() bool {
+	return logger.loggerImpl.WarnEnabled()
+}
+
+// Errorf logs message at Error level.
+func (logger *FlogoLogger) Error(message string) {
+	logger.loggerImpl.Errorf(message)
+}
+
+// ErrorEnabled checks if Error level is enabled.
+func (logger *FlogoLogger) ErrorEnabled() bool {
+	return logger.loggerImpl.ErrorEnabled()
+}
+
+//SetLog Level
+func (logger *FlogoLogger) SetLogLevel(logLevel Level) {
+	switch logLevel {
+	case Trace:
+		logger.loggerImpl.(*gol.DefaultLogger).SetLevel(gol.Trace)
+	case Debug:
+		logger.loggerImpl.(*gol.DefaultLogger).SetLevel(gol.Debug)
+	case Info:
+		logger.loggerImpl.(*gol.DefaultLogger).SetLevel(gol.Info)
+	case Error:
+		logger.loggerImpl.(*gol.DefaultLogger).SetLevel(gol.Error)
+	case Warn:
+		logger.loggerImpl.(*gol.DefaultLogger).SetLevel(gol.Warn)
+	default:
+		logger.loggerImpl.(*gol.DefaultLogger).SetLevel(gol.Error)
+	}
+}
+
+func GetLogger(name string) Logger {
+	logger := gol.GetLogger(name)
+	return &FlogoLogger{
+		loggerName: name,
+		loggerImpl: logger,
+	}
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,27 +1,28 @@
 package logger
 
 import (
-	"github.com/goburrow/gol"
+	"fmt"
+	"github.com/Sirupsen/logrus"
+	"strings"
 )
 
 type Logger interface {
-	Trace(string)
-	TraceEnabled() bool
-	Debug(string)
+	Debug(...interface{})
 	DebugEnabled() bool
-	Info(string)
+	Info(...interface{})
 	InfoEnabled() bool
-	Warn(string)
+	Warn(...interface{})
 	WarnEnabled() bool
-	Error(string)
+	Error(...interface{})
 	ErrorEnabled() bool
 	SetLogLevel(Level)
 }
 type Level int
 
+var loggerMap = make(map[string]interface{})
+
 const (
-	Trace Level = iota
-	Debug
+	Debug Level = iota
 	Info
 	Warn
 	Error
@@ -29,80 +30,112 @@ const (
 
 type FlogoLogger struct {
 	loggerName string
-	loggerImpl gol.Logger
+	loggerImpl *logrus.Logger
 }
 
-func (logger *FlogoLogger) Trace(message string) {
-	logger.loggerImpl.Tracef(message)
+const ()
+
+func init() {
+
 }
 
-// TraceEnabled checks if Trace level is enabled.
-func (logger *FlogoLogger) TraceEnabled() bool {
-	return logger.loggerImpl.TraceEnabled()
+type FlogoFormatter struct {
+	loggerName string
+}
+
+func (f *FlogoFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+
+	logEntry := fmt.Sprintf("%s %-6s [%s] - %s\n", entry.Time.Format("2006-01-02 15:04:05.000000"), getLevel(entry.Level), f.loggerName, strings.TrimPrefix(strings.TrimSuffix(entry.Message, "]"), "["))
+	return []byte(logEntry), nil
+}
+
+func getLevel(level logrus.Level) string {
+	switch level {
+	case logrus.DebugLevel:
+		return "DEBUG"
+	case logrus.InfoLevel:
+		return "INFO"
+	case logrus.ErrorLevel:
+		return "ERROR"
+	case logrus.WarnLevel:
+		return "WARN"
+	case logrus.PanicLevel:
+		return "PANIC"
+	case logrus.FatalLevel:
+		return "FATAL"
+	}
+
+	return "UNKNOWN"
 }
 
 // Debugf logs message at Debug level.
-func (logger *FlogoLogger) Debug(message string) {
-	logger.loggerImpl.Debugf(message)
+func (logger *FlogoLogger) Debug(args ...interface{}) {
+	logger.loggerImpl.Debug(args)
 }
 
 // DebugEnabled checks if Debug level is enabled.
 func (logger *FlogoLogger) DebugEnabled() bool {
-	return logger.loggerImpl.DebugEnabled()
+	return logger.loggerImpl.Level >= logrus.DebugLevel
 }
 
 // Infof logs message at Info level.
-func (logger *FlogoLogger) Info(message string) {
-	logger.loggerImpl.Infof(message)
+func (logger *FlogoLogger) Info(args ...interface{}) {
+	logger.loggerImpl.Info(args)
 }
 
 // InfoEnabled checks if Info level is enabled.
 func (logger *FlogoLogger) InfoEnabled() bool {
-	return logger.loggerImpl.InfoEnabled()
+	return logger.loggerImpl.Level >= logrus.InfoLevel
 }
 
 // Warnf logs message at Warning level.
-func (logger *FlogoLogger) Warn(message string) {
-	logger.loggerImpl.Warnf(message)
+func (logger *FlogoLogger) Warn(args ...interface{}) {
+	logger.loggerImpl.Warn(args)
 }
 
 // WarnEnabled checks if Warning level is enabled.
 func (logger *FlogoLogger) WarnEnabled() bool {
-	return logger.loggerImpl.WarnEnabled()
+	return logger.loggerImpl.Level >= logrus.WarnLevel
 }
 
 // Errorf logs message at Error level.
-func (logger *FlogoLogger) Error(message string) {
-	logger.loggerImpl.Errorf(message)
+func (logger *FlogoLogger) Error(args ...interface{}) {
+	logger.loggerImpl.Error(args)
 }
 
 // ErrorEnabled checks if Error level is enabled.
 func (logger *FlogoLogger) ErrorEnabled() bool {
-	return logger.loggerImpl.ErrorEnabled()
+	return logger.loggerImpl.Level >= logrus.ErrorLevel
 }
 
 //SetLog Level
 func (logger *FlogoLogger) SetLogLevel(logLevel Level) {
 	switch logLevel {
-	case Trace:
-		logger.loggerImpl.(*gol.DefaultLogger).SetLevel(gol.Trace)
 	case Debug:
-		logger.loggerImpl.(*gol.DefaultLogger).SetLevel(gol.Debug)
+		logger.loggerImpl.Level = logrus.DebugLevel
 	case Info:
-		logger.loggerImpl.(*gol.DefaultLogger).SetLevel(gol.Info)
+		logger.loggerImpl.Level = logrus.InfoLevel
 	case Error:
-		logger.loggerImpl.(*gol.DefaultLogger).SetLevel(gol.Error)
+		logger.loggerImpl.Level = logrus.ErrorLevel
 	case Warn:
-		logger.loggerImpl.(*gol.DefaultLogger).SetLevel(gol.Warn)
+		logger.loggerImpl.Level = logrus.WarnLevel
 	default:
-		logger.loggerImpl.(*gol.DefaultLogger).SetLevel(gol.Error)
+		logger.loggerImpl.Level = logrus.ErrorLevel
 	}
 }
 
 func GetLogger(name string) Logger {
-	logger := gol.GetLogger(name)
-	return &FlogoLogger{
-		loggerName: name,
-		loggerImpl: logger,
+	logger := loggerMap[name]
+	if logger == nil {
+		logImpl := logrus.New()
+		logImpl.Formatter = &FlogoFormatter{
+			loggerName: name,
+		}
+		logger = &FlogoLogger{
+			loggerName: name,
+			loggerImpl: logImpl,
+		}
+		loggerMap[name] = logger
 	}
+	return logger.(Logger)
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,5 +1,7 @@
 package logger
 
+import "errors"
+
 type Logger interface {
 	Debug(...interface{})
 	DebugEnabled() bool
@@ -31,6 +33,9 @@ func RegisterLoggerFactory(factory LoggerFactory) {
 	logFactory = factory
 }
 
-func GetLoggerFactory() LoggerFactory {
-	return logFactory
+func GetLogger(name string) (Logger, error) {
+	if logFactory == nil {
+		return nil, errors.New("No logger factory found.")
+	}
+	return logFactory.GetLogger(name)
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -3,13 +3,13 @@ package logger
 import "errors"
 
 type Logger interface {
-	Debug(agrs ...interface{})
+	Debug(args ...interface{})
     Debugf(format string, args ...interface{})
-    Info(agrs ...interface{})
+    Info(args ...interface{})
     Infof(format string, args ...interface{})
-    Warn(agrs ...interface{})
+    Warn(args ...interface{})
     Warnf(format string, args ...interface{})
-    Error(agrs ...interface{})
+    Error(args ...interface{})
     Errorf(format string, args ...interface{})
 	SetLogLevel(Level)
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,11 +1,5 @@
 package logger
 
-import (
-	"fmt"
-	"github.com/Sirupsen/logrus"
-	"strings"
-)
-
 type Logger interface {
 	Debug(...interface{})
 	DebugEnabled() bool
@@ -17,9 +11,12 @@ type Logger interface {
 	ErrorEnabled() bool
 	SetLogLevel(Level)
 }
-type Level int
 
-var loggerMap = make(map[string]interface{})
+type LoggerFactory interface {
+	GetLogger(name string) (Logger, error)
+}
+
+type Level int
 
 const (
 	Debug Level = iota
@@ -28,114 +25,12 @@ const (
 	Error
 )
 
-type FlogoLogger struct {
-	loggerName string
-	loggerImpl *logrus.Logger
+var logFactory LoggerFactory
+
+func RegisterLoggerFactory(factory LoggerFactory) {
+	logFactory = factory
 }
 
-const ()
-
-func init() {
-
-}
-
-type FlogoFormatter struct {
-	loggerName string
-}
-
-func (f *FlogoFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-
-	logEntry := fmt.Sprintf("%s %-6s [%s] - %s\n", entry.Time.Format("2006-01-02 15:04:05.000000"), getLevel(entry.Level), f.loggerName, strings.TrimPrefix(strings.TrimSuffix(entry.Message, "]"), "["))
-	return []byte(logEntry), nil
-}
-
-func getLevel(level logrus.Level) string {
-	switch level {
-	case logrus.DebugLevel:
-		return "DEBUG"
-	case logrus.InfoLevel:
-		return "INFO"
-	case logrus.ErrorLevel:
-		return "ERROR"
-	case logrus.WarnLevel:
-		return "WARN"
-	case logrus.PanicLevel:
-		return "PANIC"
-	case logrus.FatalLevel:
-		return "FATAL"
-	}
-
-	return "UNKNOWN"
-}
-
-// Debugf logs message at Debug level.
-func (logger *FlogoLogger) Debug(args ...interface{}) {
-	logger.loggerImpl.Debug(args)
-}
-
-// DebugEnabled checks if Debug level is enabled.
-func (logger *FlogoLogger) DebugEnabled() bool {
-	return logger.loggerImpl.Level >= logrus.DebugLevel
-}
-
-// Infof logs message at Info level.
-func (logger *FlogoLogger) Info(args ...interface{}) {
-	logger.loggerImpl.Info(args)
-}
-
-// InfoEnabled checks if Info level is enabled.
-func (logger *FlogoLogger) InfoEnabled() bool {
-	return logger.loggerImpl.Level >= logrus.InfoLevel
-}
-
-// Warnf logs message at Warning level.
-func (logger *FlogoLogger) Warn(args ...interface{}) {
-	logger.loggerImpl.Warn(args)
-}
-
-// WarnEnabled checks if Warning level is enabled.
-func (logger *FlogoLogger) WarnEnabled() bool {
-	return logger.loggerImpl.Level >= logrus.WarnLevel
-}
-
-// Errorf logs message at Error level.
-func (logger *FlogoLogger) Error(args ...interface{}) {
-	logger.loggerImpl.Error(args)
-}
-
-// ErrorEnabled checks if Error level is enabled.
-func (logger *FlogoLogger) ErrorEnabled() bool {
-	return logger.loggerImpl.Level >= logrus.ErrorLevel
-}
-
-//SetLog Level
-func (logger *FlogoLogger) SetLogLevel(logLevel Level) {
-	switch logLevel {
-	case Debug:
-		logger.loggerImpl.Level = logrus.DebugLevel
-	case Info:
-		logger.loggerImpl.Level = logrus.InfoLevel
-	case Error:
-		logger.loggerImpl.Level = logrus.ErrorLevel
-	case Warn:
-		logger.loggerImpl.Level = logrus.WarnLevel
-	default:
-		logger.loggerImpl.Level = logrus.ErrorLevel
-	}
-}
-
-func GetLogger(name string) Logger {
-	logger := loggerMap[name]
-	if logger == nil {
-		logImpl := logrus.New()
-		logImpl.Formatter = &FlogoFormatter{
-			loggerName: name,
-		}
-		logger = &FlogoLogger{
-			loggerName: name,
-			loggerImpl: logImpl,
-		}
-		loggerMap[name] = logger
-	}
-	return logger.(Logger)
+func GetLoggerFactory() LoggerFactory {
+	return logFactory
 }


### PR DESCRIPTION
Name based logger implementation for engine, activities and triggers.
The default implementation is based on https://github.com/sirupsen/logrus
It supports:
- Grouping of same type of activities/triggers 
- Setting different log levels for each logger

This approach will allow us to replace https://github.com/sirupsen/logrus implementation with other/better implementation without changing activity/trigger/engine code.
####################**Example**##########################
package main

import (
	"github.com/TIBCOSoftware/flogo-lib/logger"
)

func main() {

	enggLogger, _ := logger.GetLogger("engine")
	enggLogger.Info("This is Engine log message.")
	enggLogger.Infof("[%s] %s","Hello There!!", "This is formatted Engine log message.")

	logActivityLogger, _ := logger.GetLogger("tibco-log")
	logActivityLogger.SetLogLevel(logger.Error)
	logActivityLogger.Error("This is Log activity message.")
	logActivityLogger.Info("This will not be logged.")
}
2017-02-14 12:40:27.402606 INFO   [engine] - This is Engine log message.
2017-02-14 12:40:27.402746 INFO   [engine] - [Hello There!!] This is formatted Engine log message.
2017-02-14 12:40:27.402757 ERROR  [tibco-log] - This is Log activity message.
$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$




