### PR TITLE
Pluggable datetime format for logging

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,9 @@ import (
 )
 
 const (
-	LOG_LEVEL_DEFAULT         = "DEBUG"
+	LOG_LEVEL_DEFAULT         = "INFO"
+	LOG_DATE_FORMAT_DEFAULT   = "2006-01-02 15:04:05.000"
+	LOG_DATE_FORMAT_KEY       = "LOG_DATETIME_FORMAT"
 	LOG_LEVEL_KEY             = "LOG_LEVEL"
 	RUNNER_TYPE_DEFAULT       = "POOLED"
 	RUNNER_TYPE_KEY           = "RUNNER_TYPE"
@@ -59,4 +61,12 @@ func GetLogLevel() string {
 		return logLevelEnv
 	}
 	return LOG_LEVEL_DEFAULT
+}
+
+func GetLogDateTimeFormat() string {
+	logLevelEnv := os.Getenv(LOG_DATE_FORMAT_KEY)
+	if len(logLevelEnv) > 0 {
+		return logLevelEnv
+	}
+	return LOG_DATE_FORMAT_DEFAULT
 }

--- a/logger/logfactory.go
+++ b/logger/logfactory.go
@@ -26,7 +26,7 @@ type LogFormatter struct {
 }
 
 func (f *LogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-	logEntry := fmt.Sprintf("%s %-6s [%s] - %s\n", entry.Time.Format("2006-01-02 15:04:05.000000"), getLevel(entry.Level), f.loggerName, entry.Message)
+	logEntry := fmt.Sprintf("%s %-6s [%s] - %s\n", entry.Time.Format(config.GetLogDateTimeFormat()), getLevel(entry.Level), f.loggerName, entry.Message)
 	return []byte(logEntry), nil
 }
 


### PR DESCRIPTION
New environment variable 'LOG_DATETIME_FORMAT' can determine what format to use for date and time logging.
The default format is '2006-01-02 15:04:05.000'.