### PR TITLE
Safe access fixes for core/action/registry.go

### DIFF
--- a/core/action/registry.go
+++ b/core/action/registry.go
@@ -48,13 +48,13 @@ func Factories() map[string]Factory {
 	factoryMu.Lock()
 	defer factoryMu.Unlock()
 
-	newFs := make(map[string]Factory, len(factories))
+	factoriesCopy := make(map[string]Factory, len(factories))
 
 	for k, v := range factories {
-		newFs[k] = v
+		factoriesCopy[k] = v
 	}
 
-	return newFs
+	return factoriesCopy
 }
 
 func Get(id string) Action {

--- a/core/action/registry.go
+++ b/core/action/registry.go
@@ -58,6 +58,9 @@ func Factories() map[string]Factory {
 }
 
 func Get(id string) Action {
+	actionMu.Lock()
+	defer actionMu.Unlock()
+
 	return actions[id]
 }
 

--- a/core/action/registry.go
+++ b/core/action/registry.go
@@ -95,8 +95,8 @@ func Register(id string, act Action) error {
 }
 
 func Actions() map[string]Action {
-	factoryMu.Lock()
-	defer factoryMu.Unlock()
+	actionMu.Lock()
+	defer actionMu.Unlock()
 
 	actionsCopy := make(map[string]Action, len(actions))
 


### PR DESCRIPTION
Locking a mutex on reads was not being done and the wrong mutex was being used on copy.