### PR TITLE
add support for setting output on triggers in flogo.json

### DIFF
--- a/app/instances.go
+++ b/app/instances.go
@@ -48,6 +48,8 @@ func (h *InstanceHelper) CreateTriggers() (map[string]*trigger.TriggerInstance, 
 			return nil, fmt.Errorf("Cannot create Trigger nil for id '%s'", tConfig.Id)
 		}
 
+		tConfig.FixUp(newInterface.Metadata())
+
 		instances[tConfig.Id] = &trigger.TriggerInstance{Config: tConfig, Interf: newInterface}
 	}
 

--- a/core/trigger/config.go
+++ b/core/trigger/config.go
@@ -1,16 +1,61 @@
 package trigger
 
+import (
+	"github.com/TIBCOSoftware/flogo-lib/core/data"
+)
+
 // Config is the configuration for a Trigger
 type Config struct {
 	Name     string                 `json:"name"`
 	Id       string                 `json:"id"`
 	Ref      string                 `json:"ref"`
 	Settings map[string]interface{} `json:"settings"`
+	Outputs  map[string]interface{} `json:"outputs"`
 	Handlers []*HandlerConfig       `json:"handlers"`
 
 	//deprecated
 	//Settings map[string]string `json:"settings"`
 	Endpoints []*EndpointConfig `json:"endpoints"`
+}
+
+func (c *Config) FixUp(metadata *Metadata) {
+
+	// fix up top-level outputs
+	for name, value := range c.Outputs {
+
+		attr, ok := metadata.Outputs[name]
+
+		if ok {
+			newValue, err := data.CoerceToValue(value, attr.Type)
+
+			if err != nil {
+				//todo handle error
+			} else {
+				c.Outputs[name] = newValue
+			}
+		}
+	}
+
+	// fix up handler outputs
+	for _, hc := range c.Handlers {
+
+		hc.parent = c
+
+		for name, value := range hc.Outputs {
+
+			attr, ok := metadata.Outputs[name]
+
+			if ok {
+				newValue, err := data.CoerceToValue(value, attr.Type)
+
+				if err != nil {
+					//todo handle error
+				} else {
+					hc.Outputs[name] = newValue
+				}
+			}
+		}
+	}
 }
 
 func (c *Config) GetSetting(setting string) string {
@@ -19,12 +64,25 @@ func (c *Config) GetSetting(setting string) string {
 
 // HandlerConfig is the configuration for the Trigger Handler
 type HandlerConfig struct {
+	parent   *Config
 	ActionId string                 `json:"actionId"`
 	Settings map[string]interface{} `json:"settings"`
+	Outputs  map[string]interface{} `json:"outputs"`
 }
 
 func (hc *HandlerConfig) GetSetting(setting string) string {
 	return hc.Settings[setting].(string)
+}
+
+func (hc *HandlerConfig) GetOutput(name string) interface{} {
+
+	value, ok := hc.Outputs[name]
+
+	if !ok {
+		value, ok = hc.parent.Outputs[name]
+	}
+
+	return value
 }
 
 // EndpointConfig is the configuration for a specific endpoint for the


### PR DESCRIPTION
Added ability to specify output of a trigger or handler in the flogo.json.  If an output isn't specified in the handler, it will try to resolve the value using the trigger output values.

Helper method has been added to HandlerConfig to assist in value resolution:

func (hc *HandlerConfig) GetOutput(name string) interface{}