### PR TITLE
Support new resolver syntax

### DIFF
--- a/core/activity/activity.go
+++ b/core/activity/activity.go
@@ -1,7 +1,5 @@
 package activity
 
-
-
 // Activity is an interface for defining a custom Task Execution
 type Activity interface {
 

--- a/core/activity/activity.go
+++ b/core/activity/activity.go
@@ -1,5 +1,7 @@
 package activity
 
+
+
 // Activity is an interface for defining a custom Task Execution
 type Activity interface {
 

--- a/core/activity/registry.go
+++ b/core/activity/registry.go
@@ -5,7 +5,6 @@ import (
 	"github.com/TIBCOSoftware/flogo-lib/logger"
 	"github.com/TIBCOSoftware/flogo-lib/core/data"
 	"github.com/TIBCOSoftware/flogo-lib/core/expr"
-	"strings"
 )
 
 var (
@@ -23,14 +22,6 @@ func newResolver(scope data.Scope) expr.Resolver {
 }
 
 func (r *resolver) Resolve(path string) (interface{}, bool){
-	// Trim wrapper ${activity. }
-	path = strings.TrimSuffix(strings.TrimPrefix(path, "${activity."),"}")
-	// Trim activity name
-	idx := strings.Index(path, ".")
-	if idx == -1 || len(path) < idx + 1 {
-		return nil, false
-	}
-	path = path[idx + 1:]
 	attrName, attrPath, pathType := data.GetAttrPath(path)
 	return data.GetAttrValue(attrName, attrPath, pathType, r.scope)
 }

--- a/core/activity/registry_test.go
+++ b/core/activity/registry_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestResolver(t *testing.T){
 	// Resolve myStringAttribute
-	myStringAttribute := data.NewAttribute("myStringAttribute", data.STRING, "attr value")
+	myStringAttribute := data.NewAttribute("${activity.myActivity.myStringAttribute}", data.STRING, "attr value")
 	scope := data.NewSimpleScope([]*data.Attribute{myStringAttribute}, nil)
 
 	resolver := newResolver(scope)

--- a/core/activity/registry_test.go
+++ b/core/activity/registry_test.go
@@ -1,0 +1,22 @@
+package activity
+
+import (
+	"testing"
+	"github.com/TIBCOSoftware/flogo-lib/core/data"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolver(t *testing.T){
+	// Resolve myStringAttribute
+	myStringAttribute := data.NewAttribute("myStringAttribute", data.STRING, "attr value")
+	scope := data.NewSimpleScope([]*data.Attribute{myStringAttribute}, nil)
+
+	resolver := newResolver(scope)
+	result, ok := resolver.Resolve("${activity.myActivity.myStringAttribute}")
+	assert.True(t, ok)
+	assert.NotNil(t, result)
+	act, ok := result.(string)
+	assert.Equal(t,"attr value", act)
+	assert.True(t,ok)
+
+}

--- a/core/data/path.go
+++ b/core/data/path.go
@@ -13,9 +13,9 @@ type PathType int
 type ResolverType int
 
 const (
-	PT_SIMPLE   PathType = 1
-	PT_MAP      PathType = 2
-	PT_ARRAY    PathType = 3
+	PT_SIMPLE PathType = 1
+	PT_MAP    PathType = 2
+	PT_ARRAY  PathType = 3
 
 	RES_DEFAULT ResolverType = iota
 	RES_PROPERTY
@@ -25,10 +25,8 @@ const (
 
 func GetResolverType(inAttrName string) (ResolverType, error) {
 	if strings.HasPrefix(inAttrName, "${") {
-		// Get value between ${ and }
 		leftIdx := 2
-		rightIdx := strings.Index(inAttrName, "}")
-		fullExpr := inAttrName[leftIdx:rightIdx]
+		fullExpr := inAttrName[leftIdx:]
 		if len(fullExpr) == 0 {
 			return 0, fmt.Errorf("Invalid mapping expression [%s].", inAttrName)
 		}
@@ -77,7 +75,7 @@ func GetAttrPath(inAttrName string) (attrName string, attrPath string, pathType 
 				attrPath = inAttrName[idx+2:]
 			}
 		}
-	} else if strings.HasPrefix(inAttrName, "${"){
+	} else if strings.HasPrefix(inAttrName, "${") {
 		idx := strings.Index(inAttrName, "}")
 
 		if idx == nameLen-1 {
@@ -174,9 +172,9 @@ func GetMapValue(valueMap map[string]interface{}, path string) interface{} {
 	return tmpObj
 }
 
-func GetAttrValue(attrName, attrPath string, pathType PathType, scope Scope) (interface{}, bool){
+func GetAttrValue(attrName, attrPath string, pathType PathType, scope Scope) (interface{}, bool) {
 	tv, exists := scope.GetAttr(attrName)
-	if tv == nil{
+	if tv == nil {
 		return nil, false
 	}
 	attrValue := tv.Value
@@ -187,7 +185,7 @@ func GetAttrValue(attrName, attrPath string, pathType PathType, scope Scope) (in
 		} else if tv.Type == ARRAY && pathType == PT_ARRAY {
 			//assigning part of array
 			idx, err := strconv.Atoi(attrPath)
-			if err != nil{
+			if err != nil {
 				return nil, false
 			}
 			valArray := attrValue.([]interface{})

--- a/core/data/path.go
+++ b/core/data/path.go
@@ -77,6 +77,22 @@ func GetAttrPath(inAttrName string) (attrName string, attrPath string, pathType 
 				attrPath = inAttrName[idx+2:]
 			}
 		}
+	} else if strings.HasPrefix(inAttrName, "${"){
+		idx := strings.Index(inAttrName, "}")
+
+		if idx == nameLen-1 {
+			attrName = inAttrName
+		} else {
+			attrName = inAttrName[:idx+1]
+
+			if inAttrName[idx+1] == '[' {
+				pathType = PT_ARRAY
+				attrPath = inAttrName[idx+2 : nameLen-1]
+			} else {
+				pathType = PT_MAP
+				attrPath = inAttrName[idx+2:]
+			}
+		}
 	} else {
 		idx := strings.Index(inAttrName, ".")
 
@@ -170,8 +186,10 @@ func GetAttrValue(attrName, attrPath string, pathType PathType, scope Scope) (in
 			attrValue, exists = valMap[attrPath]
 		} else if tv.Type == ARRAY && pathType == PT_ARRAY {
 			//assigning part of array
-			idx, _ := strconv.Atoi(attrPath)
-			//todo handle err
+			idx, err := strconv.Atoi(attrPath)
+			if err != nil{
+				return nil, false
+			}
 			valArray := attrValue.([]interface{})
 			attrValue = valArray[idx]
 		} else {

--- a/core/data/path_test.go
+++ b/core/data/path_test.go
@@ -38,35 +38,37 @@ func TestGetAttrPath(t *testing.T) {
 	name, path, pt = GetAttrPath(a)
 	fmt.Printf("Name: %s, Path: %s, PathType: %d\n", name, path, pt)
 
+
+}
+
+func TestGetResolverType(t *testing.T) {
 	// Resolution of Property expression
-	a = "${property.Prop1}"
-	name, path, pt = GetAttrPath(a)
-	fmt.Printf("Name: %s, Path: %s, PathType: %d\n", name, path, pt)
-	assert.Equal(t, "property", name)
-	assert.Equal(t, "Prop1", path)
-	assert.Equal(t, pt, PT_PROPERTY)
+	a := "${property.Prop1}"
+	resType, err := GetResolverType(a)
+	assert.Nil(t, err)
+	assert.Equal(t, RES_PROPERTY, resType)
 
 	// Resolution of Environment expression
 	a = "${env.VAR1}"
-	name, path, pt = GetAttrPath(a)
-	fmt.Printf("Name: %s, Path: %s, PathType: %d\n", name, path, pt)
-	assert.Equal(t, "env", name)
-	assert.Equal(t, "VAR1", path)
-	assert.Equal(t, pt, PT_PROPERTY)
+	resType, err = GetResolverType(a)
+	assert.Nil(t, err)
+	assert.Equal(t, RES_PROPERTY, resType)
 
-	// Resolution of flat Activity expression
-	a = "${activity.myActivity}"
-	name, path, pt = GetAttrPath(a)
-	fmt.Printf("Name: %s, Path: %s, PathType: %d\n", name, path, pt)
-	assert.Equal(t, "activity", name)
-	assert.Equal(t, "myActivity", path)
-	assert.Equal(t, pt, PT_ACTIVITY)
+	// Resolution of first level Activity expression
+	a = "${activity.myStringAttribute}"
+	resType, err = GetResolverType(a)
+	assert.Nil(t, err)
+	assert.Equal(t, RES_ACTIVITY, resType)
+
+	// Resolution of second level Activity expression
+	a = "${activity.myMapAttribute.myMapKey}"
+	resType, err = GetResolverType(a)
+	assert.Nil(t, err)
+	assert.Equal(t, RES_ACTIVITY, resType)
 
 	// Resolution of flat Trigger expression
 	a = "${trigger.myTrigger}"
-	name, path, pt = GetAttrPath(a)
-	fmt.Printf("Name: %s, Path: %s, PathType: %d\n", name, path, pt)
-	assert.Equal(t, "trigger", name)
-	assert.Equal(t, "myTrigger", path)
-	assert.Equal(t, pt, PT_TRIGGER)
+	resType, err = GetResolverType(a)
+	assert.Nil(t, err)
+	assert.Equal(t, RES_TRIGGER, resType)
 }

--- a/core/data/path_test.go
+++ b/core/data/path_test.go
@@ -38,6 +38,14 @@ func TestGetAttrPath(t *testing.T) {
 	name, path, pt = GetAttrPath(a)
 	fmt.Printf("Name: %s, Path: %s, PathType: %d\n", name, path, pt)
 
+
+	// Resolution of old Trigger activity expression
+	a = "{T.pathParams}.myParam"
+	name, path, pt = GetAttrPath(a)
+	assert.Equal(t, "{T.pathParams}", name)
+	assert.Equal(t, "myParam", path)
+	assert.Equal(t, PT_MAP, pt)
+
 	// Resolution of activity expression
 	a = "${activity.my_activityid.mystring}"
 	name, path, pt = GetAttrPath(a)
@@ -62,9 +70,15 @@ func TestGetAttrPath(t *testing.T) {
 }
 
 func TestGetResolverType(t *testing.T) {
-	// Resolution of Property expression
-	a := "${property.Prop1}"
+	// Resolution of Old Trigger expression
+	a := "{T.pathParams}.myParam"
 	resType, err := GetResolverType(a)
+	assert.Nil(t, err)
+	assert.Equal(t, RES_DEFAULT, resType)
+
+	// Resolution of Property expression
+	a = "${property.Prop1}"
+	resType, err = GetResolverType(a)
 	assert.Nil(t, err)
 	assert.Equal(t, RES_PROPERTY, resType)
 

--- a/core/data/path_test.go
+++ b/core/data/path_test.go
@@ -38,6 +38,26 @@ func TestGetAttrPath(t *testing.T) {
 	name, path, pt = GetAttrPath(a)
 	fmt.Printf("Name: %s, Path: %s, PathType: %d\n", name, path, pt)
 
+	// Resolution of activity expression
+	a = "${activity.my_activityid.mystring}"
+	name, path, pt = GetAttrPath(a)
+	assert.Equal(t, "${activity.my_activityid.mystring}", name)
+	assert.Equal(t, "", path)
+	assert.Equal(t, PT_SIMPLE, pt)
+
+	// Resolution of activity expression
+	a = "${activity.my_activityid.mymap}.mypath"
+	name, path, pt = GetAttrPath(a)
+	assert.Equal(t, "${activity.my_activityid.mymap}", name)
+	assert.Equal(t, "mypath", path)
+	assert.Equal(t, PT_MAP, pt)
+
+	// Resolution of activity expression
+	a = "${activity.my_activityid.myarray}[0]"
+	name, path, pt = GetAttrPath(a)
+	assert.Equal(t, "${activity.my_activityid.myarray}", name)
+	assert.Equal(t, "0", path)
+	assert.Equal(t, PT_ARRAY, pt)
 
 }
 

--- a/core/data/path_test.go
+++ b/core/data/path_test.go
@@ -3,6 +3,8 @@ package data
 import (
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetAttrPath(t *testing.T) {
@@ -35,12 +37,36 @@ func TestGetAttrPath(t *testing.T) {
 	a = "{T1.v}"
 	name, path, pt = GetAttrPath(a)
 	fmt.Printf("Name: %s, Path: %s, PathType: %d\n", name, path, pt)
-	
+
+	// Resolution of Property expression
 	a = "${property.Prop1}"
 	name, path, pt = GetAttrPath(a)
 	fmt.Printf("Name: %s, Path: %s, PathType: %d\n", name, path, pt)
-	
+	assert.Equal(t, "property", name)
+	assert.Equal(t, "Prop1", path)
+	assert.Equal(t, pt, PT_PROPERTY)
+
+	// Resolution of Environment expression
 	a = "${env.VAR1}"
 	name, path, pt = GetAttrPath(a)
 	fmt.Printf("Name: %s, Path: %s, PathType: %d\n", name, path, pt)
+	assert.Equal(t, "env", name)
+	assert.Equal(t, "VAR1", path)
+	assert.Equal(t, pt, PT_PROPERTY)
+
+	// Resolution of flat Activity expression
+	a = "${activity.myActivity}"
+	name, path, pt = GetAttrPath(a)
+	fmt.Printf("Name: %s, Path: %s, PathType: %d\n", name, path, pt)
+	assert.Equal(t, "activity", name)
+	assert.Equal(t, "myActivity", path)
+	assert.Equal(t, pt, PT_ACTIVITY)
+
+	// Resolution of flat Trigger expression
+	a = "${trigger.myTrigger}"
+	name, path, pt = GetAttrPath(a)
+	fmt.Printf("Name: %s, Path: %s, PathType: %d\n", name, path, pt)
+	assert.Equal(t, "trigger", name)
+	assert.Equal(t, "myTrigger", path)
+	assert.Equal(t, pt, PT_TRIGGER)
 }

--- a/core/data/path_test.go
+++ b/core/data/path_test.go
@@ -89,13 +89,19 @@ func TestGetResolverType(t *testing.T) {
 	assert.Equal(t, RES_PROPERTY, resType)
 
 	// Resolution of first level Activity expression
-	a = "${activity.myStringAttribute}"
+	a = "${activity.myactivityId.myAttributeName}"
 	resType, err = GetResolverType(a)
 	assert.Nil(t, err)
 	assert.Equal(t, RES_ACTIVITY, resType)
 
-	// Resolution of second level Activity expression
-	a = "${activity.myMapAttribute.myMapKey}"
+	// Resolution of second level Activity expression map
+	a = "${activity.myactivityId.myMapAttributeName}.mapkey"
+	resType, err = GetResolverType(a)
+	assert.Nil(t, err)
+	assert.Equal(t, RES_ACTIVITY, resType)
+
+	// Resolution of second level Activity expression array
+	a = "${activity.myactivityId.myMapAttributeName}[0]"
 	resType, err = GetResolverType(a)
 	assert.Nil(t, err)
 	assert.Equal(t, RES_ACTIVITY, resType)

--- a/core/expr/resolver.go
+++ b/core/expr/resolver.go
@@ -1,0 +1,8 @@
+package expr
+
+// Resolve value sourced from Environment variable or any other configuration management services
+type Resolver interface {
+	// Resolve value for given name
+	// Returns resolved value and true otherwise nil and false in case it can not resolve the value.
+	Resolve(name string) (interface{}, bool)
+}

--- a/core/expr/resolver.go
+++ b/core/expr/resolver.go
@@ -1,8 +1,7 @@
 package expr
 
-// Resolve value sourced from Environment variable or any other configuration management services
+// Resolve interface, resolves a value for a given name
 type Resolver interface {
-	// Resolve value for given name
 	// Returns resolved value and true otherwise nil and false in case it can not resolve the value.
 	Resolve(name string) (interface{}, bool)
 }

--- a/core/property/registry.go
+++ b/core/property/registry.go
@@ -2,26 +2,21 @@ package property
 
 import (
 	"fmt"
-	"github.com/TIBCOSoftware/flogo-lib/logger"
 	"os"
 	"reflect"
 	"strings"
 	"sync"
+
+	"github.com/TIBCOSoftware/flogo-lib/core/expr"
+	"github.com/TIBCOSoftware/flogo-lib/logger"
 )
 
 var (
 	props = make(map[string]interface{})
 	mut   = sync.RWMutex{}
 	// Default Resolver
-	resolver Resolver = &DefaultResolver{}
+	resolver expr.Resolver = &DefaultResolver{}
 )
-
-// Resolve value sourced from Enviornment variable or any other configuration management services
-type Resolver interface {
-	// Resolve value for given name
-	// Returns resolved value and true ortherwise nil and false in case it can not resolve the value.
-	Resolve(name string) (interface{}, bool)
-}
 
 // Default resolver to resolve property and envioronment variable values.
 type DefaultResolver struct {
@@ -103,7 +98,7 @@ func Register(id string, value interface{}) error {
 
 // Register new resolver with the engine.
 // It will override default resolver.
-func RegisterResolver(newresolver Resolver) {
+func RegisterResolver(newresolver expr.Resolver) {
 	if newresolver != nil {
 		mut.Lock()
 		defer mut.Unlock()

--- a/core/trigger/registry.go
+++ b/core/trigger/registry.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"github.com/TIBCOSoftware/flogo-lib/logger"
 	"sync"
+	"github.com/TIBCOSoftware/flogo-lib/core/data"
+	"github.com/TIBCOSoftware/flogo-lib/core/expr"
 )
 
 var (
@@ -22,6 +24,20 @@ type Registry interface {
 type registry struct {
 	factories map[string]Factory
 	instances map[string]*TriggerInstance
+}
+
+// Resolver resolves the trigger for a given scope and path
+type resolver struct {
+	scope data.Scope
+}
+
+func newResolver(scope data.Scope) expr.Resolver {
+	return &resolver{scope: scope}
+}
+
+func (r *resolver) Resolve(path string) (interface{}, bool){
+	attrName, attrPath, pathType := data.GetAttrPath(path)
+	return data.GetAttrValue(attrName, attrPath, pathType, r.scope)
 }
 
 func GetRegistry() Registry {
@@ -179,4 +195,9 @@ func GetTriggerInstanceInfo() []TriggerInstanceInfo {
 		})
 	}
 	return list
+}
+
+// Resolve will resolve the activity for the given path
+func Resolve(scope data.Scope, path string) (interface{}, bool){
+	return newResolver(scope).Resolve(path)
 }


### PR DESCRIPTION
Support new syntax on input mapper and branch conditions:

New format explained here: http://confluence.tibco.com/display/FLOGO/Architecture#Architecture-ExpressionSyntaxProposal

This solution is backward compatible with old format.