### PR TITLE
Add couple of static functions

### DIFF
--- a/core/mapper/exprmapper/function/number/random/random.go
+++ b/core/mapper/exprmapper/function/number/random/random.go
@@ -1,10 +1,10 @@
 package random
 
 import (
-	"encoding/json"
 	"math/rand"
-	"strconv"
 	"time"
+
+	"github.com/TIBCOSoftware/flogo-lib/core/data"
 
 	"github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/expression/function"
 	"github.com/TIBCOSoftware/flogo-lib/logger"
@@ -27,36 +27,13 @@ func (s *Random) GetCategory() string {
 	return "number"
 }
 
-func (s *Random) Eval(limitIn interface{}) int64 {
-	limit, err := ConvertToInt64(limitIn)
+func (s *Random) Eval(limitIn interface{}) int {
+	limit, err := data.CoerceToInteger(limitIn)
 	if err != nil {
 		log.Errorf("Convert %+v to int error %s", limitIn, err.Error())
 		limit = 10
 	}
 	log.Debugf("Generate sudo-random integer number within the scope of [0, %d)", limit)
 	rand.Seed(time.Now().UnixNano())
-	return rand.Int63n(limit)
-}
-
-func ConvertToInt64(value interface{}) (int64, error) {
-	switch t := value.(type) {
-	case string:
-		return strconv.ParseInt(t, 10, 64)
-	case int:
-		return int64(t), nil
-	case int64:
-		return t, nil
-	case float64:
-		return int64(t), nil
-	default:
-		v, err := json.Marshal(value)
-		if err != nil {
-			return 0, err
-		}
-		i, err := strconv.ParseInt(string(v), 10, 64)
-		if err != nil {
-			return 0, err
-		}
-		return i, nil
-	}
+	return rand.Intn(limit)
 }

--- a/core/mapper/exprmapper/function/number/random/random.go
+++ b/core/mapper/exprmapper/function/number/random/random.go
@@ -1,0 +1,62 @@
+package random
+
+import (
+	"encoding/json"
+	"math/rand"
+	"strconv"
+	"time"
+
+	"github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/expression/function"
+	"github.com/TIBCOSoftware/flogo-lib/logger"
+)
+
+var log = logger.GetLogger("random-function")
+
+type Random struct {
+}
+
+func init() {
+	function.Registry(&Random{})
+}
+
+func (s *Random) GetName() string {
+	return "random"
+}
+
+func (s *Random) GetCategory() string {
+	return "number"
+}
+
+func (s *Random) Eval(limitIn interface{}) int64 {
+	limit, err := ConvertToInt64(limitIn)
+	if err != nil {
+		log.Errorf("Convert %+v to int error %s", limitIn, err.Error())
+		limit = 10
+	}
+	log.Debugf("Generate sudo-random integer number within the scope of [0, %d)", limit)
+	rand.Seed(time.Now().UnixNano())
+	return rand.Int63n(limit)
+}
+
+func ConvertToInt64(value interface{}) (int64, error) {
+	switch t := value.(type) {
+	case string:
+		return strconv.ParseInt(t, 10, 64)
+	case int:
+		return int64(t), nil
+	case int64:
+		return t, nil
+	case float64:
+		return int64(t), nil
+	default:
+		v, err := json.Marshal(value)
+		if err != nil {
+			return 0, err
+		}
+		i, err := strconv.ParseInt(string(v), 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		return i, nil
+	}
+}

--- a/core/mapper/exprmapper/function/number/random/random_test.go
+++ b/core/mapper/exprmapper/function/number/random/random_test.go
@@ -1,0 +1,26 @@
+package random
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/expression"
+	"github.com/stretchr/testify/assert"
+)
+
+var s = &Random{}
+
+func TestSample(t *testing.T) {
+	final1 := s.Eval(100)
+	assert.NotNil(t, final1)
+}
+
+func TestExpression(t *testing.T) {
+	fun, err := expression.NewFunctionExpression(`number.random(100000)`).GetFunction()
+	assert.Nil(t, err)
+	assert.NotNil(t, fun)
+	v, err := fun.Eval()
+	assert.Nil(t, err)
+	assert.NotNil(t, v[0])
+	fmt.Println(v)
+}

--- a/core/mapper/exprmapper/function/string/concat/concat.go
+++ b/core/mapper/exprmapper/function/string/concat/concat.go
@@ -1,0 +1,41 @@
+package concat
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/expression/function"
+	"github.com/TIBCOSoftware/flogo-lib/logger"
+)
+
+var log = logger.GetLogger("concat-function")
+
+type Concat struct {
+}
+
+func init() {
+	function.Registry(&Concat{})
+}
+
+func (s *Concat) GetName() string {
+	return "concat"
+}
+
+func (s *Concat) GetCategory() string {
+	return "string"
+}
+
+func (s *Concat) Eval(strs ...string) (string, error) {
+	log.Debugf("Start concat function with parameters %s", strs)
+	if len(strs) >= 2 {
+		var buffer bytes.Buffer
+
+		for _, v := range strs {
+			buffer.WriteString(v)
+		}
+		log.Debugf("Done concat function with result %s", buffer.String())
+		return buffer.String(), nil
+	}
+
+	return "", fmt.Errorf("Concat function at least have 2 arguments")
+}

--- a/core/mapper/exprmapper/function/string/concat/concat_test.go
+++ b/core/mapper/exprmapper/function/string/concat/concat_test.go
@@ -1,0 +1,103 @@
+package concat
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/expression"
+	"github.com/stretchr/testify/assert"
+)
+
+var s = &Concat{}
+
+func TestStaticFunc_Concat(t *testing.T) {
+	final, err := s.Eval("TIBCO", "FLOGO", "IOT")
+	assert.Nil(t, err)
+	fmt.Println(final)
+	assert.Equal(t, final, "TIBCOFLOGOIOT")
+}
+
+func TestExpressionDoubleQuotes(t *testing.T) {
+	fun, err := expression.NewFunctionExpression(`string.concat('TIBCO',' Flo"go')`).GetFunction()
+	assert.Nil(t, err)
+	assert.NotNil(t, fun)
+	v, err := fun.Eval()
+	assert.Nil(t, err)
+	assert.Equal(t, `TIBCO Flo"go`, v[0])
+}
+
+func TestExpressionSingleQuote(t *testing.T) {
+	fun, err := expression.NewFunctionExpression(`string.concat("TIBCO"," Flo'o\o{go")`).GetFunction()
+	assert.Nil(t, err)
+	assert.NotNil(t, fun)
+	v, err := fun.Eval()
+	assert.Nil(t, err)
+	assert.Equal(t, "TIBCO Flo'o\\o{go", v[0])
+}
+
+func TestExpressionCombine(t *testing.T) {
+	fun, err := expression.NewFunctionExpression(`string.concat('Hello', " 'World'")`).GetFunction()
+	assert.Nil(t, err)
+	assert.NotNil(t, fun)
+	v, err := fun.Eval()
+	assert.Nil(t, err)
+	assert.Equal(t, `Hello 'World'`, v[0])
+}
+
+func TestExpressionCombine2(t *testing.T) {
+	fun, err := expression.NewFunctionExpression(`string.concat('Hello', ' "World"')`).GetFunction()
+	assert.Nil(t, err)
+	assert.NotNil(t, fun)
+	v, err := fun.Eval()
+	assert.Nil(t, err)
+	assert.Equal(t, `Hello "World"`, v[0])
+}
+func TestExpressionNewLine(t *testing.T) {
+	fun, err := expression.NewFunctionExpression(`string.concat(
+	"TIBCO",
+	" FLOGO"
+	)`).GetFunction()
+	assert.Nil(t, err)
+	assert.NotNil(t, fun)
+	v, err := fun.Eval()
+	assert.Nil(t, err)
+	assert.Equal(t, "TIBCO FLOGO", v[0])
+}
+
+func TestExpressionSpace(t *testing.T) {
+	fun, err := expression.NewFunctionExpression(`string.concat(    "TIBCO"  ,  " FLOGO")   `).GetFunction()
+	assert.Nil(t, err)
+	assert.NotNil(t, fun)
+	v, err := fun.Eval()
+	assert.Nil(t, err)
+	assert.Equal(t, "TIBCO FLOGO", v[0])
+}
+
+func TestExpressionSpaceNewLineTab(t *testing.T) {
+	fun, err := expression.NewFunctionExpression(`string.concat(    "TIBCO" 
+		 ,	" FLOGO"	
+		 )`).GetFunction()
+	assert.Nil(t, err)
+	assert.NotNil(t, fun)
+	v, err := fun.Eval()
+	assert.Nil(t, err)
+	assert.Equal(t, "TIBCO FLOGO", v[0])
+}
+
+func TestExpressionDoubleDoubleQuotes(t *testing.T) {
+	fun, err := expression.NewFunctionExpression(`string.concat("\"abc\"", "dddd")`).GetFunction()
+	assert.Nil(t, err)
+	assert.NotNil(t, fun)
+	v, err := fun.Eval()
+	assert.Nil(t, err)
+	assert.Equal(t, `"abc"dddd`, v[0])
+}
+
+func TestExpressionSingleSingleQuote(t *testing.T) {
+	fun, err := expression.NewFunctionExpression(`string.concat('\'b\'ac\'', "dddd")`).GetFunction()
+	assert.Nil(t, err)
+	assert.NotNil(t, fun)
+	v, err := fun.Eval()
+	assert.Nil(t, err)
+	assert.Equal(t, `'b'ac'dddd`, v[0])
+}

--- a/core/mapper/exprmapper/function/string/equals/equals.go
+++ b/core/mapper/exprmapper/function/string/equals/equals.go
@@ -1,0 +1,32 @@
+package equals
+
+import (
+	"strings"
+
+	"github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/expression/function"
+	"github.com/TIBCOSoftware/flogo-lib/logger"
+)
+
+var log = logger.GetLogger("equals-function")
+
+type Equals struct {
+}
+
+func init() {
+	function.Registry(&Equals{})
+}
+
+func (s *Equals) GetName() string {
+	return "equals"
+}
+
+func (s *Equals) GetCategory() string {
+	return "string"
+}
+func (s *Equals) Eval(str, str2 string, ignoreCase bool) bool {
+	log.Debugf(`Reports whether "%s" equels "%s" with ignore case %s`, str, str2, ignoreCase)
+	if ignoreCase {
+		return strings.EqualFold(str, str2)
+	}
+	return str == str2
+}

--- a/core/mapper/exprmapper/function/string/equals/equals_test.go
+++ b/core/mapper/exprmapper/function/string/equals/equals_test.go
@@ -1,0 +1,42 @@
+package equals
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/expression"
+	"github.com/stretchr/testify/assert"
+)
+
+var s = &Equals{}
+
+func TestStaticFunc_Starts_with(t *testing.T) {
+	final1 := s.Eval("TIBCO FLOGO", "TIBCO", true)
+	fmt.Println(final1)
+	assert.Equal(t, false, final1)
+
+	final2 := s.Eval("TIBCO", "tibco", true)
+	fmt.Println(final2)
+	assert.Equal(t, true, final2)
+
+}
+
+func TestExpression(t *testing.T) {
+	fun, err := expression.NewFunctionExpression(`string.equals("TIBCO FLOGO", "TIBCO FLOGO", false)`).GetFunction()
+	assert.Nil(t, err)
+	assert.NotNil(t, fun)
+	v, err := fun.Eval()
+	assert.Nil(t, err)
+	assert.NotNil(t, v)
+	assert.Equal(t, true, v[0])
+}
+
+func TestExpressionIgnoreCase(t *testing.T) {
+	fun, err := expression.NewFunctionExpression(`string.equals("TIBCO flogo", "TIBCO FLOGO", true)`).GetFunction()
+	assert.Nil(t, err)
+	assert.NotNil(t, fun)
+	v, err := fun.Eval()
+	assert.Nil(t, err)
+	assert.NotNil(t, v)
+	assert.Equal(t, true, v[0])
+}

--- a/core/mapper/exprmapper/function/string/length/length.go
+++ b/core/mapper/exprmapper/function/string/length/length.go
@@ -1,0 +1,31 @@
+package length
+
+import (
+	"github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/expression/function"
+	"github.com/TIBCOSoftware/flogo-lib/logger"
+)
+
+var log = logger.GetLogger("length-function")
+
+type Length struct {
+}
+
+func init() {
+	function.Registry(&Length{})
+}
+
+func (s *Length) GetName() string {
+	return "length"
+}
+
+func (s *Length) GetCategory() string {
+	return "string"
+}
+
+func (s *Length) Eval(str string) int {
+	log.Debugf("Return the length of a string \"%s\"", str)
+	var l int
+	l = len(str)
+	log.Debugf("Done calculating the length %d", l)
+	return l
+}

--- a/core/mapper/exprmapper/function/string/length/length_test.go
+++ b/core/mapper/exprmapper/function/string/length/length_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var s = &StringLength{}
+var s = &Length{}
 
 func TestStaticFunc_String_length(t *testing.T) {
 	final11 := s.Eval("TIBCO FLOGO")

--- a/core/mapper/exprmapper/function/string/length/length_test.go
+++ b/core/mapper/exprmapper/function/string/length/length_test.go
@@ -1,0 +1,31 @@
+package length
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/expression"
+	"github.com/stretchr/testify/assert"
+)
+
+var s = &StringLength{}
+
+func TestStaticFunc_String_length(t *testing.T) {
+	final11 := s.Eval("TIBCO FLOGO")
+	fmt.Println(final11)
+	assert.Equal(t, 11, final11)
+
+	final2 := s.Eval("你好, FLOGO")
+	fmt.Println(final2)
+	assert.Equal(t, 13, final2)
+}
+
+func TestExpression(t *testing.T) {
+	fun, err := expression.NewFunctionExpression(`string.length("seafood,name")`).GetFunction()
+	assert.Nil(t, err)
+	assert.NotNil(t, fun)
+	v, err := fun.Eval()
+	assert.Nil(t, err)
+	assert.NotNil(t, v)
+	assert.Equal(t, 12, v[0])
+}


### PR DESCRIPTION
I going to add some `string` and `number` static functions to show how to use the function in expr mapper, especially in documentation.

Functions
```
string.length("str")
string.equals("str1", "str2", ignorecase)
string.concat("str1","str2","str3"...)
number.random(100)
```