### PR TITLE
logging and bubbling up error when failing to parse trigger input attrs

### DIFF
--- a/core/trigger/handler.go
+++ b/core/trigger/handler.go
@@ -2,6 +2,7 @@ package trigger
 
 import (
 	"context"
+
 	"github.com/TIBCOSoftware/flogo-lib/core/action"
 	"github.com/TIBCOSoftware/flogo-lib/core/data"
 	"github.com/TIBCOSoftware/flogo-lib/core/mapper"
@@ -127,7 +128,12 @@ func (h *Handler) generateInputs(triggerData map[string]interface{}) (map[string
 		return nil, nil
 	}
 
-	triggerAttrs, _ := h.dataToAttrs(triggerData)
+	triggerAttrs, err := h.dataToAttrs(triggerData)
+
+	if err != nil {
+		logger.Errorf("Failed parsing attrs: %s, Error: %s", triggerData, err)
+		return nil, err
+	}
 
 	if len(triggerAttrs) == 0 {
 		return nil, nil


### PR DESCRIPTION
When a trigger input attr is an object, but a string is passed rather than a json obj no issue is currently logged and future mappings that rely on the trigger->flow inputs do not work.

For now, just grabbing the coercion error, logging and bubbling it up.