### PR TITLE
Handle $. to get current scope attr data

### DIFF
--- a/core/data/resolve.go
+++ b/core/data/resolve.go
@@ -123,15 +123,16 @@ type ResolutionDetails struct {
 }
 
 func GetResolutionDetails(toResolve string) (*ResolutionDetails, error) {
+
 	//todo optimize, maybe tokenize first
 
 	dotIdx := strings.Index(toResolve, ".")
+
 	if dotIdx == -1 {
 		return nil, fmt.Errorf("invalid resolution expression [%s]", toResolve)
 	}
 
 	details := &ResolutionDetails{}
-
 	itemIdx := strings.Index(toResolve[:dotIdx], "[")
 
 	if itemIdx != -1 {
@@ -163,7 +164,6 @@ func GetResolutionDetails(toResolve string) (*ResolutionDetails, error) {
 	}
 
 	return details, nil
-
 }
 
 func GetResolutionDetailsOld(toResolve string) (*ResolutionDetails, error) {

--- a/core/data/resolve_test.go
+++ b/core/data/resolve_test.go
@@ -150,7 +150,7 @@ func TestGetResolutionDetailsOld(t *testing.T) {
 
 	// Resolution of second level Activity expression map
 	a = "${activity.myactivityId.myMapAttributeName}.mapkey"
-	details, err = GetResolutionDetails(a)
+	details, err = GetResolutionDetailsOld(a)
 	assert.Nil(t, err)
 	assert.Equal(t, "activity", details.ResolverName)
 	assert.Equal(t, "myMapAttributeName", details.Property)

--- a/core/data/resolve_test.go
+++ b/core/data/resolve_test.go
@@ -1,8 +1,9 @@
 package data
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetResolutionDetails(t *testing.T) {
@@ -49,7 +50,6 @@ func TestGetResolutionDetails(t *testing.T) {
 	assert.Equal(t, "myactivityId", details.Item)
 	assert.Equal(t, "myMapAttributeName", details.Property)
 	assert.Equal(t, `["a.b"]`, details.Path)
-
 
 	// Resolution of second level Activity expression array
 	a = "activity.myactivityId.myArrayAttributeName[0]"
@@ -150,7 +150,7 @@ func TestGetResolutionDetailsOld(t *testing.T) {
 
 	// Resolution of second level Activity expression map
 	a = "${activity.myactivityId.myMapAttributeName}.mapkey"
-	details, err = GetResolutionDetailsOld(a)
+	details, err = GetResolutionDetails(a)
 	assert.Nil(t, err)
 	assert.Equal(t, "activity", details.ResolverName)
 	assert.Equal(t, "myMapAttributeName", details.Property)
@@ -165,4 +165,28 @@ func TestGetResolutionDetailsOld(t *testing.T) {
 	assert.Equal(t, "myArrayAttributeName", details.Property)
 	assert.Equal(t, "myactivityId", details.Item)
 	assert.Equal(t, "[0]", details.Path)
+}
+
+func TestSimpleScopeResolve(t *testing.T) {
+	a := "$.header.Accept"
+	details, err := GetResolutionDetails(a)
+	assert.Nil(t, err)
+	assert.Equal(t, "$.", details.ResolverName)
+	assert.Equal(t, "header", details.Property)
+	assert.Equal(t, "Accept", details.Path)
+
+	a = "$.array[0]"
+	details, err = GetResolutionDetails(a)
+	assert.Nil(t, err)
+	assert.Equal(t, "$.", details.ResolverName)
+	assert.Equal(t, "array", details.Property)
+	assert.Equal(t, "[0]", details.Path)
+
+	a = "$.headers"
+	details, err = GetResolutionDetails(a)
+	assert.Nil(t, err)
+	assert.Equal(t, "$.", details.ResolverName)
+	assert.Equal(t, "headers", details.Property)
+	assert.Equal(t, "", details.Path)
+
 }

--- a/core/data/resolve_test.go
+++ b/core/data/resolve_test.go
@@ -167,13 +167,13 @@ func TestGetResolutionDetailsOld(t *testing.T) {
 	assert.Equal(t, "[0]", details.Path)
 }
 
-func TestSimpleScopeResolve(t *testing.T) {
+func TestToGetCurrentScope(t *testing.T) {
 	a := "$.header.Accept"
 	details, err := GetResolutionDetails(a)
 	assert.Nil(t, err)
 	assert.Equal(t, "$.", details.ResolverName)
 	assert.Equal(t, "header", details.Property)
-	assert.Equal(t, "Accept", details.Path)
+	assert.Equal(t, ".Accept", details.Path)
 
 	a = "$.array[0]"
 	details, err = GetResolutionDetails(a)

--- a/core/mapper/exprmapper/json/field/field.go
+++ b/core/mapper/exprmapper/json/field/field.go
@@ -9,6 +9,7 @@ import (
 )
 
 var log = logger.GetLogger("expr-mapper-field")
+
 type MappingField struct {
 	HasSpecialField bool
 	HasArray        bool
@@ -22,8 +23,8 @@ func GetAllspecialFields(path string) ([]string, error) {
 	var lastIndex = 0
 	matches := re.FindAllStringIndex(path, -1)
 	for i, match := range matches {
-		log.Debugf("Mathing index %d", match)
-		log.Debugf("Mathing string %s", path[match[0]:match[1]])
+		//log.Debugf("Mathing index %d", match)
+		//log.Debugf("Mathing string %s", path[match[0]:match[1]])
 
 		if i == 0 && lastIndex == 0 {
 			startPart := trimDot(path[:match[0]])

--- a/core/mapper/exprmapper/ref/mappingref.go
+++ b/core/mapper/exprmapper/ref/mappingref.go
@@ -118,7 +118,6 @@ func (m *MappingRef) getValueFromAttribute(inputscope data.Scope, resolver data.
 		}
 	} else {
 		newRef = resolutionDetails.ResolverName + resolutionDetails.Property
-
 	}
 
 	log.Debugf("Activity and root field name is: %s", newRef)

--- a/core/mapper/exprmapper/ref/mappingref.go
+++ b/core/mapper/exprmapper/ref/mappingref.go
@@ -109,7 +109,12 @@ func (m *MappingRef) getValueFromAttribute(inputscope data.Scope, resolver data.
 	//Only need activity and field name
 	resolutionDetails.Path = ""
 	//var newRef string
-	newRef := resolutionDetails.ResolverName + "[" + resolutionDetails.Item + "]" + "." + resolutionDetails.Property
+	var newRef string
+	if resolutionDetails.Item != "" {
+		newRef = resolutionDetails.ResolverName + "[" + resolutionDetails.Item + "]" + "." + resolutionDetails.Property
+	} else {
+		newRef = resolutionDetails.ResolverName + "." + resolutionDetails.Property
+	}
 
 	log.Debugf("Activity and root field name is: %s", newRef)
 	value, err := resolver.Resolve(newRef, inputscope)

--- a/core/mapper/exprmapper/ref/mappingref.go
+++ b/core/mapper/exprmapper/ref/mappingref.go
@@ -110,10 +110,15 @@ func (m *MappingRef) getValueFromAttribute(inputscope data.Scope, resolver data.
 	resolutionDetails.Path = ""
 	//var newRef string
 	var newRef string
-	if resolutionDetails.Item != "" {
-		newRef = resolutionDetails.ResolverName + "[" + resolutionDetails.Item + "]" + "." + resolutionDetails.Property
+	if resolutionDetails.ResolverName != "$." {
+		if resolutionDetails.Item != "" {
+			newRef = resolutionDetails.ResolverName + "[" + resolutionDetails.Item + "]" + "." + resolutionDetails.Property
+		} else {
+			newRef = resolutionDetails.ResolverName + "." + resolutionDetails.Property
+		}
 	} else {
-		newRef = resolutionDetails.ResolverName + "." + resolutionDetails.Property
+		newRef = resolutionDetails.ResolverName + resolutionDetails.Property
+
 	}
 
 	log.Debugf("Activity and root field name is: %s", newRef)


### PR DESCRIPTION
The PR to fix the issue to map current scope data in action mapping.   such as map rest trigger header or body into flow input or map flow output to trigger output.

Sample trigger mapping.

```json
{
    "mappings": {
        "input": [
            {
                "mapTo": "inputparam",
                "type": "expression",
                "value": "$.headers.Accept"
            },
            {
                "mapTo": "inputparam2",
                "type": "assign",
                "value": "$.body[0].name"
            },
            {
                "mapTo": "inputparam3",
                "type": "assign",
                "value": "$.body"
            }
        ],
        "output": [
            {
                "mapTo": "$INPUT['data']['replymessage']",
                "type": "expression",
                "value": "$.outputparam"
            },
            {
                "mapTo": "data.replymessage2",
                "type": "assign",
                "value": "$.outputparam2"
            },
            {
                "mapTo": "data.replymessage3[0]",
                "type": "expression",
                "value": "$.outputparam3"
            },
            {
                "mapTo": "$INPUT['code']",
                "type": "expression",
                "value": 200
            }
        ]
    }
}
```
