### PR TITLE
Action mapping should be evaluated irrespective of trigger output

### DIFF
--- a/core/trigger/handler.go
+++ b/core/trigger/handler.go
@@ -125,19 +125,11 @@ func (h *Handler) dataToAttrs(triggerData map[string]interface{}) ([]*data.Attri
 
 func (h *Handler) generateInputs(triggerData map[string]interface{}) (map[string]*data.Attribute, error) {
 
-	if len(triggerData) == 0 {
-		return nil, nil
-	}
-
 	triggerAttrs, err := h.dataToAttrs(triggerData)
 
 	if err != nil {
 		logger.Errorf("Failed parsing attrs: %s, Error: %s", triggerData, err)
 		return nil, err
-	}
-
-	if len(triggerAttrs) == 0 {
-		return nil, nil
 	}
 
 	var inputs map[string]*data.Attribute


### PR DESCRIPTION
Today, action mappings are not evaluated if trigger has no output.
Since, value could be hardcoded and not referenced from the trigger, runtime should evaluate such mappings.