### PR TITLE
Add action metadata into inputs no matter has input mapper or not

### DIFF
--- a/core/trigger/handler.go
+++ b/core/trigger/handler.go
@@ -3,11 +3,12 @@ package trigger
 import (
 	"context"
 
+	"fmt"
+
 	"github.com/TIBCOSoftware/flogo-lib/core/action"
 	"github.com/TIBCOSoftware/flogo-lib/core/data"
 	"github.com/TIBCOSoftware/flogo-lib/core/mapper"
 	"github.com/TIBCOSoftware/flogo-lib/logger"
-	"fmt"
 )
 
 type Handler struct {
@@ -182,6 +183,14 @@ func (h *Handler) generateInputs(triggerData map[string]interface{}) (map[string
 
 			attrName := "_T." + attr.Name()
 			inputs[attrName] = data.CloneAttribute(attrName, attr)
+		}
+
+		//Add action metadata into flow
+		if h.act.IOMetadata() != nil && h.act.IOMetadata().Input != nil {
+			//Adding action metadat into inputs
+			for _, attr := range h.act.IOMetadata().Input {
+				inputs[attr.Name()] = attr
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes: # .

**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**What is the current behavior?**
Action metadata attr cannot be found in scope while there is no action input mapper
**What is the new behavior?**
Add action metadata into scope no matter it has action input mapper or not.
