### PR TITLE
Use default log level when invalid value is set

### DIFF
--- a/logger/exported.go
+++ b/logger/exported.go
@@ -41,6 +41,7 @@ func SetLogLevel(level Level) {
 }
 
 var defaultLoggerName = "flogo"
+var defaultLogLevel = "INFO"
 
 func SetDefaultLogger(name string) {
 	defaultLoggerName = name

--- a/logger/logfactory.go
+++ b/logger/logfactory.go
@@ -145,7 +145,7 @@ func (logfactory *DefaultLoggerFactory) GetLogger(name string) Logger {
 		// Get log level for name
 		level, err := GetLevelForName(logLevelName)
 		if err != nil {
-			return nil
+			panic(fmt.Sprintf("Unsupported Log Level - [%s]. Supported Value - [INFO DEBUG WARN ERROR]", logLevelName))
 		}
 		l.SetLogLevel(level)
 		mutex.Lock()

--- a/logger/logfactory.go
+++ b/logger/logfactory.go
@@ -10,12 +10,22 @@ import (
 
 var loggerMap = make(map[string]Logger)
 var mutex = &sync.RWMutex{}
-
+var logLevel = InfoLevel
 type DefaultLoggerFactory struct {
 }
 
 func init() {
+
 	RegisterLoggerFactory(&DefaultLoggerFactory{})
+
+	logLevelName := config.GetLogLevel()
+	// Get log level for name
+	getLogLevel, err := GetLevelForName(logLevelName)
+	if err != nil {
+		println("Unsupported Log Level - ["+logLevelName+"]. Set to Log Level - ["+defaultLogLevel+"]")
+	} else {
+		logLevel = getLogLevel
+	}
 }
 
 type DefaultLogger struct {
@@ -140,14 +150,9 @@ func (logfactory *DefaultLoggerFactory) GetLogger(name string) Logger {
 			loggerName: name,
 			loggerImpl: logImpl,
 		}
-		// Get log level from config
-		logLevelName := config.GetLogLevel()
-		// Get log level for name
-		level, err := GetLevelForName(logLevelName)
-		if err != nil {
-			panic(fmt.Sprintf("Unsupported Log Level - [%s]. Supported Value - [INFO DEBUG WARN ERROR]", logLevelName))
-		}
-		l.SetLogLevel(level)
+
+		l.SetLogLevel(logLevel)
+
 		mutex.Lock()
 		loggerMap[name] = l
 		mutex.Unlock()


### PR DESCRIPTION
Fixes: TIBCOSoftware/flogo#204 .

**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**What is the current behavior?**
For invalid log level, nil is returned which causes downstream code to throw error.
**What is the new behavior?**
For invalid log level, it will use default log level.
Unsupported Log Level - [INF0]. Set to Log Level - [INFO]