### PR TITLE
Expression support boolean to fix #152

### DIFF
--- a/core/mapper/exprmapper/expression/gocc/flogo.bnf
+++ b/core/mapper/exprmapper/expression/gocc/flogo.bnf
@@ -125,6 +125,7 @@ Expr
     | Float                   <<direction.NewExpressionField($0)>>
     | DoubleQString           <<direction.NewExpressionField($0)>>
     | SingleQString           <<direction.NewExpressionField($0)>>
+    | Bool                    <<direction.NewExpressionField($0)>>
     | MappingRef              <<direction.NewExpressionField($0)>>
     | Func1                   <<direction.NewExpressionField($0)>>
     | Expr Operator Expr      <<direction.NewExpression($0, $1, $2) >>

--- a/core/mapper/exprmapper/expression/gocc/parser/actiontable.go
+++ b/core/mapper/exprmapper/expression/gocc/parser/actiontable.go
@@ -21,13 +21,13 @@ var actionTab = actionTable{
 			nil,       /* ) */
 			nil,       /* () */
 			nil,       /* delimitor_param */
-			shift(11), /* doublequotes_string */
-			shift(12), /* singlequote_string */
-			shift(13), /* number */
-			shift(14), /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			shift(15), /* float */
+			shift(12), /* doublequotes_string */
+			shift(13), /* singlequote_string */
+			shift(14), /* number */
+			shift(15), /* argument */
+			shift(16), /* true */
+			shift(17), /* false */
+			shift(18), /* float */
 			nil,       /* operator_charactor */
 			nil,       /* ? */
 			nil,       /* : */
@@ -72,8 +72,8 @@ var actionTab = actionTable{
 			nil,        /* true */
 			nil,        /* false */
 			nil,        /* float */
-			reduce(25), /* operator_charactor, reduce: Expr */
-			reduce(25), /* ?, reduce: Expr */
+			reduce(26), /* operator_charactor, reduce: Expr */
+			reduce(26), /* ?, reduce: Expr */
 			nil,        /* : */
 		},
 	},
@@ -94,8 +94,8 @@ var actionTab = actionTable{
 			nil,        /* true */
 			nil,        /* false */
 			nil,        /* float */
-			shift(18),  /* operator_charactor */
-			reduce(30), /* ?, reduce: TernaryExp */
+			shift(21),  /* operator_charactor */
+			reduce(31), /* ?, reduce: TernaryExp */
 			nil,        /* : */
 		},
 	},
@@ -105,9 +105,9 @@ var actionTab = actionTable{
 			nil,       /* INVALID */
 			nil,       /* $ */
 			nil,       /* function_name */
-			shift(19), /* ( */
+			shift(22), /* ( */
 			nil,       /* ) */
-			shift(20), /* () */
+			shift(23), /* () */
 			nil,       /* delimitor_param */
 			nil,       /* doublequotes_string */
 			nil,       /* singlequote_string */
@@ -126,18 +126,18 @@ var actionTab = actionTable{
 		actions: [numSymbols]action{
 			nil,       /* INVALID */
 			nil,       /* $ */
-			shift(23), /* function_name */
-			shift(24), /* ( */
+			shift(26), /* function_name */
+			shift(27), /* ( */
 			nil,       /* ) */
 			nil,       /* () */
 			nil,       /* delimitor_param */
-			shift(30), /* doublequotes_string */
-			shift(31), /* singlequote_string */
-			shift(32), /* number */
-			shift(33), /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			shift(34), /* float */
+			shift(34), /* doublequotes_string */
+			shift(35), /* singlequote_string */
+			shift(36), /* number */
+			shift(37), /* argument */
+			shift(38), /* true */
+			shift(39), /* false */
+			shift(40), /* float */
 			nil,       /* operator_charactor */
 			nil,       /* ? */
 			nil,       /* : */
@@ -257,6 +257,28 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
+			reduce(25), /* $, reduce: Expr */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(25), /* operator_charactor, reduce: Expr */
+			reduce(25), /* ?, reduce: Expr */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S12
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
 			reduce(13), /* $, reduce: DoubleQString */
 			nil,        /* function_name */
 			nil,        /* ( */
@@ -275,7 +297,7 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S12
+	actionRow{ // S13
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -297,7 +319,7 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S13
+	actionRow{ // S14
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -319,7 +341,7 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S14
+	actionRow{ // S15
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -341,7 +363,51 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S15
+	actionRow{ // S16
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			reduce(17), /* $, reduce: Bool */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(17), /* operator_charactor, reduce: Bool */
+			reduce(17), /* ?, reduce: Bool */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S17
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			reduce(18), /* $, reduce: Bool */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(18), /* operator_charactor, reduce: Bool */
+			reduce(18), /* ?, reduce: Bool */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S18
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -363,11 +429,11 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S16
+	actionRow{ // S19
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
-			reduce(27), /* $, reduce: Expr */
+			reduce(28), /* $, reduce: Expr */
 			nil,        /* function_name */
 			nil,        /* ( */
 			nil,        /* ) */
@@ -380,12 +446,12 @@ var actionTab = actionTable{
 			nil,        /* true */
 			nil,        /* false */
 			nil,        /* float */
-			reduce(27), /* operator_charactor, reduce: Expr */
-			shift(36),  /* ? */
+			reduce(28), /* operator_charactor, reduce: Expr */
+			shift(42),  /* ? */
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S17
+	actionRow{ // S20
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       /* INVALID */
@@ -395,63 +461,63 @@ var actionTab = actionTable{
 			nil,       /* ) */
 			nil,       /* () */
 			nil,       /* delimitor_param */
-			shift(11), /* doublequotes_string */
-			shift(12), /* singlequote_string */
-			shift(13), /* number */
-			shift(14), /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			shift(15), /* float */
+			shift(12), /* doublequotes_string */
+			shift(13), /* singlequote_string */
+			shift(14), /* number */
+			shift(15), /* argument */
+			shift(16), /* true */
+			shift(17), /* false */
+			shift(18), /* float */
 			nil,       /* operator_charactor */
 			nil,       /* ? */
 			nil,       /* : */
 		},
 	},
-	actionRow{ // S18
+	actionRow{ // S21
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
 			nil,        /* $ */
-			reduce(29), /* function_name, reduce: Operator */
-			reduce(29), /* (, reduce: Operator */
+			reduce(30), /* function_name, reduce: Operator */
+			reduce(30), /* (, reduce: Operator */
 			nil,        /* ) */
 			nil,        /* () */
 			nil,        /* delimitor_param */
-			reduce(29), /* doublequotes_string, reduce: Operator */
-			reduce(29), /* singlequote_string, reduce: Operator */
-			reduce(29), /* number, reduce: Operator */
-			reduce(29), /* argument, reduce: Operator */
-			nil,        /* true */
-			nil,        /* false */
-			reduce(29), /* float, reduce: Operator */
+			reduce(30), /* doublequotes_string, reduce: Operator */
+			reduce(30), /* singlequote_string, reduce: Operator */
+			reduce(30), /* number, reduce: Operator */
+			reduce(30), /* argument, reduce: Operator */
+			reduce(30), /* true, reduce: Operator */
+			reduce(30), /* false, reduce: Operator */
+			reduce(30), /* float, reduce: Operator */
 			nil,        /* operator_charactor */
 			nil,        /* ? */
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S19
+	actionRow{ // S22
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       /* INVALID */
 			nil,       /* $ */
-			shift(40), /* function_name */
+			shift(46), /* function_name */
 			nil,       /* ( */
 			nil,       /* ) */
 			nil,       /* () */
 			nil,       /* delimitor_param */
-			shift(48), /* doublequotes_string */
-			shift(49), /* singlequote_string */
-			shift(50), /* number */
-			shift(51), /* argument */
-			shift(52), /* true */
-			shift(53), /* false */
-			shift(54), /* float */
+			shift(54), /* doublequotes_string */
+			shift(55), /* singlequote_string */
+			shift(56), /* number */
+			shift(57), /* argument */
+			shift(58), /* true */
+			shift(59), /* false */
+			shift(60), /* float */
 			nil,       /* operator_charactor */
 			nil,       /* ? */
 			nil,       /* : */
 		},
 	},
-	actionRow{ // S20
+	actionRow{ // S23
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       /* INVALID */
@@ -473,7 +539,205 @@ var actionTab = actionTable{
 			nil,       /* : */
 		},
 	},
-	actionRow{ // S21
+	actionRow{ // S24
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(26), /* ), reduce: Expr */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(26), /* operator_charactor, reduce: Expr */
+			reduce(26), /* ?, reduce: Expr */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S25
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			shift(61),  /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			shift(21),  /* operator_charactor */
+			reduce(31), /* ?, reduce: TernaryExp */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S26
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			nil,       /* function_name */
+			shift(63), /* ( */
+			nil,       /* ) */
+			shift(64), /* () */
+			nil,       /* delimitor_param */
+			nil,       /* doublequotes_string */
+			nil,       /* singlequote_string */
+			nil,       /* number */
+			nil,       /* argument */
+			nil,       /* true */
+			nil,       /* false */
+			nil,       /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S27
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			shift(26), /* function_name */
+			shift(27), /* ( */
+			nil,       /* ) */
+			nil,       /* () */
+			nil,       /* delimitor_param */
+			shift(34), /* doublequotes_string */
+			shift(35), /* singlequote_string */
+			shift(36), /* number */
+			shift(37), /* argument */
+			shift(38), /* true */
+			shift(39), /* false */
+			shift(40), /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S28
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(22), /* ), reduce: Expr */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(22), /* operator_charactor, reduce: Expr */
+			reduce(22), /* ?, reduce: Expr */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S29
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(23), /* ), reduce: Expr */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(23), /* operator_charactor, reduce: Expr */
+			reduce(23), /* ?, reduce: Expr */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S30
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(20), /* ), reduce: Expr */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(20), /* operator_charactor, reduce: Expr */
+			reduce(20), /* ?, reduce: Expr */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S31
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(21), /* ), reduce: Expr */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(21), /* operator_charactor, reduce: Expr */
+			reduce(21), /* ?, reduce: Expr */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S32
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(24), /* ), reduce: Expr */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(24), /* operator_charactor, reduce: Expr */
+			reduce(24), /* ?, reduce: Expr */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S33
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -495,183 +759,7 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S22
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			shift(55),  /* ) */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			shift(18),  /* operator_charactor */
-			reduce(30), /* ?, reduce: TernaryExp */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S23
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			nil,       /* function_name */
-			shift(57), /* ( */
-			nil,       /* ) */
-			shift(58), /* () */
-			nil,       /* delimitor_param */
-			nil,       /* doublequotes_string */
-			nil,       /* singlequote_string */
-			nil,       /* number */
-			nil,       /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			nil,       /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S24
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			shift(23), /* function_name */
-			shift(24), /* ( */
-			nil,       /* ) */
-			nil,       /* () */
-			nil,       /* delimitor_param */
-			shift(30), /* doublequotes_string */
-			shift(31), /* singlequote_string */
-			shift(32), /* number */
-			shift(33), /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			shift(34), /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S25
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			reduce(22), /* ), reduce: Expr */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			reduce(22), /* operator_charactor, reduce: Expr */
-			reduce(22), /* ?, reduce: Expr */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S26
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			reduce(23), /* ), reduce: Expr */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			reduce(23), /* operator_charactor, reduce: Expr */
-			reduce(23), /* ?, reduce: Expr */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S27
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			reduce(20), /* ), reduce: Expr */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			reduce(20), /* operator_charactor, reduce: Expr */
-			reduce(20), /* ?, reduce: Expr */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S28
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			reduce(21), /* ), reduce: Expr */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			reduce(21), /* operator_charactor, reduce: Expr */
-			reduce(21), /* ?, reduce: Expr */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S29
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			reduce(24), /* ), reduce: Expr */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			reduce(24), /* operator_charactor, reduce: Expr */
-			reduce(24), /* ?, reduce: Expr */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S30
+	actionRow{ // S34
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -693,7 +781,7 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S31
+	actionRow{ // S35
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -715,7 +803,7 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S32
+	actionRow{ // S36
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -737,7 +825,7 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S33
+	actionRow{ // S37
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -759,7 +847,51 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S34
+	actionRow{ // S38
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(17), /* ), reduce: Bool */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(17), /* operator_charactor, reduce: Bool */
+			reduce(17), /* ?, reduce: Bool */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S39
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(18), /* ), reduce: Bool */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(18), /* operator_charactor, reduce: Bool */
+			reduce(18), /* ?, reduce: Bool */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S40
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -781,14 +913,14 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S35
+	actionRow{ // S41
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
 			nil,        /* $ */
 			nil,        /* function_name */
 			nil,        /* ( */
-			reduce(27), /* ), reduce: Expr */
+			reduce(28), /* ), reduce: Expr */
 			nil,        /* () */
 			nil,        /* delimitor_param */
 			nil,        /* doublequotes_string */
@@ -798,56 +930,34 @@ var actionTab = actionTable{
 			nil,        /* true */
 			nil,        /* false */
 			nil,        /* float */
-			reduce(27), /* operator_charactor, reduce: Expr */
-			shift(60),  /* ? */
+			reduce(28), /* operator_charactor, reduce: Expr */
+			shift(66),  /* ? */
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S36
+	actionRow{ // S42
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       /* INVALID */
 			nil,       /* $ */
-			shift(64), /* function_name */
-			shift(65), /* ( */
+			shift(70), /* function_name */
+			shift(71), /* ( */
 			nil,       /* ) */
 			nil,       /* () */
 			nil,       /* delimitor_param */
-			shift(71), /* doublequotes_string */
-			shift(72), /* singlequote_string */
-			shift(73), /* number */
-			shift(74), /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			shift(75), /* float */
+			shift(78), /* doublequotes_string */
+			shift(79), /* singlequote_string */
+			shift(80), /* number */
+			shift(81), /* argument */
+			shift(82), /* true */
+			shift(83), /* false */
+			shift(84), /* float */
 			nil,       /* operator_charactor */
 			nil,       /* ? */
 			nil,       /* : */
 		},
 	},
-	actionRow{ // S37
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			reduce(25), /* $, reduce: Expr */
-			nil,        /* function_name */
-			nil,        /* ( */
-			nil,        /* ) */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			reduce(25), /* operator_charactor, reduce: Expr */
-			reduce(25), /* ?, reduce: Expr */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S38
+	actionRow{ // S43
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -864,12 +974,34 @@ var actionTab = actionTable{
 			nil,        /* true */
 			nil,        /* false */
 			nil,        /* float */
-			shift(18),  /* operator_charactor */
+			reduce(26), /* operator_charactor, reduce: Expr */
 			reduce(26), /* ?, reduce: Expr */
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S39
+	actionRow{ // S44
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			reduce(27), /* $, reduce: Expr */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			shift(21),  /* operator_charactor */
+			reduce(27), /* ?, reduce: Expr */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S45
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -891,535 +1023,7 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S40
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			nil,       /* function_name */
-			shift(78), /* ( */
-			nil,       /* ) */
-			shift(79), /* () */
-			nil,       /* delimitor_param */
-			nil,       /* doublequotes_string */
-			nil,       /* singlequote_string */
-			nil,       /* number */
-			nil,       /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			nil,       /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S41
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			nil,       /* function_name */
-			nil,       /* ( */
-			shift(80), /* ) */
-			nil,       /* () */
-			shift(81), /* delimitor_param */
-			nil,       /* doublequotes_string */
-			nil,       /* singlequote_string */
-			nil,       /* number */
-			nil,       /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			nil,       /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S42
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			nil,       /* function_name */
-			nil,       /* ( */
-			reduce(5), /* ), reduce: Args */
-			nil,       /* () */
-			reduce(5), /* delimitor_param, reduce: Args */
-			nil,       /* doublequotes_string */
-			nil,       /* singlequote_string */
-			nil,       /* number */
-			nil,       /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			nil,       /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S43
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			nil,       /* function_name */
-			nil,       /* ( */
-			reduce(6), /* ), reduce: Args */
-			nil,       /* () */
-			reduce(6), /* delimitor_param, reduce: Args */
-			nil,       /* doublequotes_string */
-			nil,       /* singlequote_string */
-			nil,       /* number */
-			nil,       /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			nil,       /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S44
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			nil,       /* function_name */
-			nil,       /* ( */
-			reduce(7), /* ), reduce: Args */
-			nil,       /* () */
-			reduce(7), /* delimitor_param, reduce: Args */
-			nil,       /* doublequotes_string */
-			nil,       /* singlequote_string */
-			nil,       /* number */
-			nil,       /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			nil,       /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S45
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			nil,       /* function_name */
-			nil,       /* ( */
-			reduce(8), /* ), reduce: Args */
-			nil,       /* () */
-			reduce(8), /* delimitor_param, reduce: Args */
-			nil,       /* doublequotes_string */
-			nil,       /* singlequote_string */
-			nil,       /* number */
-			nil,       /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			nil,       /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
 	actionRow{ // S46
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			nil,       /* function_name */
-			nil,       /* ( */
-			reduce(9), /* ), reduce: Args */
-			nil,       /* () */
-			reduce(9), /* delimitor_param, reduce: Args */
-			nil,       /* doublequotes_string */
-			nil,       /* singlequote_string */
-			nil,       /* number */
-			nil,       /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			nil,       /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S47
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			reduce(10), /* ), reduce: Args */
-			nil,        /* () */
-			reduce(10), /* delimitor_param, reduce: Args */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			nil,        /* operator_charactor */
-			nil,        /* ? */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S48
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			reduce(13), /* ), reduce: DoubleQString */
-			nil,        /* () */
-			reduce(13), /* delimitor_param, reduce: DoubleQString */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			nil,        /* operator_charactor */
-			nil,        /* ? */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S49
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			reduce(14), /* ), reduce: SingleQString */
-			nil,        /* () */
-			reduce(14), /* delimitor_param, reduce: SingleQString */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			nil,        /* operator_charactor */
-			nil,        /* ? */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S50
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			reduce(15), /* ), reduce: Int */
-			nil,        /* () */
-			reduce(15), /* delimitor_param, reduce: Int */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			nil,        /* operator_charactor */
-			nil,        /* ? */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S51
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			reduce(16), /* ), reduce: MappingRef */
-			nil,        /* () */
-			reduce(16), /* delimitor_param, reduce: MappingRef */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			nil,        /* operator_charactor */
-			nil,        /* ? */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S52
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			reduce(17), /* ), reduce: Bool */
-			nil,        /* () */
-			reduce(17), /* delimitor_param, reduce: Bool */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			nil,        /* operator_charactor */
-			nil,        /* ? */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S53
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			reduce(18), /* ), reduce: Bool */
-			nil,        /* () */
-			reduce(18), /* delimitor_param, reduce: Bool */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			nil,        /* operator_charactor */
-			nil,        /* ? */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S54
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			reduce(19), /* ), reduce: Float */
-			nil,        /* () */
-			reduce(19), /* delimitor_param, reduce: Float */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			nil,        /* operator_charactor */
-			nil,        /* ? */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S55
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			reduce(28), /* $, reduce: Expr */
-			nil,        /* function_name */
-			nil,        /* ( */
-			nil,        /* ) */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			reduce(28), /* operator_charactor, reduce: Expr */
-			reduce(28), /* ?, reduce: Expr */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S56
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			shift(23), /* function_name */
-			shift(24), /* ( */
-			nil,       /* ) */
-			nil,       /* () */
-			nil,       /* delimitor_param */
-			shift(30), /* doublequotes_string */
-			shift(31), /* singlequote_string */
-			shift(32), /* number */
-			shift(33), /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			shift(34), /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S57
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			shift(40), /* function_name */
-			nil,       /* ( */
-			nil,       /* ) */
-			nil,       /* () */
-			nil,       /* delimitor_param */
-			shift(48), /* doublequotes_string */
-			shift(49), /* singlequote_string */
-			shift(50), /* number */
-			shift(51), /* argument */
-			shift(52), /* true */
-			shift(53), /* false */
-			shift(54), /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S58
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			nil,       /* function_name */
-			nil,       /* ( */
-			reduce(4), /* ), reduce: Func1 */
-			nil,       /* () */
-			nil,       /* delimitor_param */
-			nil,       /* doublequotes_string */
-			nil,       /* singlequote_string */
-			nil,       /* number */
-			nil,       /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			nil,       /* float */
-			reduce(4), /* operator_charactor, reduce: Func1 */
-			reduce(4), /* ?, reduce: Func1 */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S59
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			shift(84),  /* ) */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			shift(18),  /* operator_charactor */
-			reduce(30), /* ?, reduce: TernaryExp */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S60
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			shift(64), /* function_name */
-			shift(65), /* ( */
-			nil,       /* ) */
-			nil,       /* () */
-			nil,       /* delimitor_param */
-			shift(71), /* doublequotes_string */
-			shift(72), /* singlequote_string */
-			shift(73), /* number */
-			shift(74), /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			shift(75), /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S61
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			nil,        /* ) */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			nil,        /* operator_charactor */
-			nil,        /* ? */
-			reduce(37), /* :, reduce: TernaryParam */
-		},
-	},
-	actionRow{ // S62
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			nil,        /* ) */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			reduce(25), /* operator_charactor, reduce: Expr */
-			reduce(25), /* ?, reduce: Expr */
-			reduce(1),  /* :, reduce: Func */
-		},
-	},
-	actionRow{ // S63
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			nil,        /* ) */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			shift(18),  /* operator_charactor */
-			reduce(30), /* ?, reduce: TernaryExp */
-			reduce(2),  /* :, reduce: Func */
-		},
-	},
-	actionRow{ // S64
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       /* INVALID */
@@ -1441,29 +1045,557 @@ var actionTab = actionTable{
 			nil,       /* : */
 		},
 	},
-	actionRow{ // S65
+	actionRow{ // S47
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       /* INVALID */
 			nil,       /* $ */
-			shift(23), /* function_name */
-			shift(24), /* ( */
-			nil,       /* ) */
+			nil,       /* function_name */
+			nil,       /* ( */
+			shift(89), /* ) */
 			nil,       /* () */
-			nil,       /* delimitor_param */
-			shift(30), /* doublequotes_string */
-			shift(31), /* singlequote_string */
-			shift(32), /* number */
-			shift(33), /* argument */
+			shift(90), /* delimitor_param */
+			nil,       /* doublequotes_string */
+			nil,       /* singlequote_string */
+			nil,       /* number */
+			nil,       /* argument */
 			nil,       /* true */
 			nil,       /* false */
-			shift(34), /* float */
+			nil,       /* float */
 			nil,       /* operator_charactor */
 			nil,       /* ? */
 			nil,       /* : */
 		},
 	},
+	actionRow{ // S48
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			nil,       /* function_name */
+			nil,       /* ( */
+			reduce(5), /* ), reduce: Args */
+			nil,       /* () */
+			reduce(5), /* delimitor_param, reduce: Args */
+			nil,       /* doublequotes_string */
+			nil,       /* singlequote_string */
+			nil,       /* number */
+			nil,       /* argument */
+			nil,       /* true */
+			nil,       /* false */
+			nil,       /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S49
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			nil,       /* function_name */
+			nil,       /* ( */
+			reduce(6), /* ), reduce: Args */
+			nil,       /* () */
+			reduce(6), /* delimitor_param, reduce: Args */
+			nil,       /* doublequotes_string */
+			nil,       /* singlequote_string */
+			nil,       /* number */
+			nil,       /* argument */
+			nil,       /* true */
+			nil,       /* false */
+			nil,       /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S50
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			nil,       /* function_name */
+			nil,       /* ( */
+			reduce(7), /* ), reduce: Args */
+			nil,       /* () */
+			reduce(7), /* delimitor_param, reduce: Args */
+			nil,       /* doublequotes_string */
+			nil,       /* singlequote_string */
+			nil,       /* number */
+			nil,       /* argument */
+			nil,       /* true */
+			nil,       /* false */
+			nil,       /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S51
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			nil,       /* function_name */
+			nil,       /* ( */
+			reduce(8), /* ), reduce: Args */
+			nil,       /* () */
+			reduce(8), /* delimitor_param, reduce: Args */
+			nil,       /* doublequotes_string */
+			nil,       /* singlequote_string */
+			nil,       /* number */
+			nil,       /* argument */
+			nil,       /* true */
+			nil,       /* false */
+			nil,       /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S52
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			nil,       /* function_name */
+			nil,       /* ( */
+			reduce(9), /* ), reduce: Args */
+			nil,       /* () */
+			reduce(9), /* delimitor_param, reduce: Args */
+			nil,       /* doublequotes_string */
+			nil,       /* singlequote_string */
+			nil,       /* number */
+			nil,       /* argument */
+			nil,       /* true */
+			nil,       /* false */
+			nil,       /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S53
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(10), /* ), reduce: Args */
+			nil,        /* () */
+			reduce(10), /* delimitor_param, reduce: Args */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			nil,        /* operator_charactor */
+			nil,        /* ? */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S54
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(13), /* ), reduce: DoubleQString */
+			nil,        /* () */
+			reduce(13), /* delimitor_param, reduce: DoubleQString */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			nil,        /* operator_charactor */
+			nil,        /* ? */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S55
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(14), /* ), reduce: SingleQString */
+			nil,        /* () */
+			reduce(14), /* delimitor_param, reduce: SingleQString */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			nil,        /* operator_charactor */
+			nil,        /* ? */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S56
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(15), /* ), reduce: Int */
+			nil,        /* () */
+			reduce(15), /* delimitor_param, reduce: Int */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			nil,        /* operator_charactor */
+			nil,        /* ? */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S57
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(16), /* ), reduce: MappingRef */
+			nil,        /* () */
+			reduce(16), /* delimitor_param, reduce: MappingRef */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			nil,        /* operator_charactor */
+			nil,        /* ? */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S58
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(17), /* ), reduce: Bool */
+			nil,        /* () */
+			reduce(17), /* delimitor_param, reduce: Bool */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			nil,        /* operator_charactor */
+			nil,        /* ? */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S59
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(18), /* ), reduce: Bool */
+			nil,        /* () */
+			reduce(18), /* delimitor_param, reduce: Bool */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			nil,        /* operator_charactor */
+			nil,        /* ? */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S60
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(19), /* ), reduce: Float */
+			nil,        /* () */
+			reduce(19), /* delimitor_param, reduce: Float */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			nil,        /* operator_charactor */
+			nil,        /* ? */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S61
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			reduce(29), /* $, reduce: Expr */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(29), /* operator_charactor, reduce: Expr */
+			reduce(29), /* ?, reduce: Expr */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S62
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			shift(26), /* function_name */
+			shift(27), /* ( */
+			nil,       /* ) */
+			nil,       /* () */
+			nil,       /* delimitor_param */
+			shift(34), /* doublequotes_string */
+			shift(35), /* singlequote_string */
+			shift(36), /* number */
+			shift(37), /* argument */
+			shift(38), /* true */
+			shift(39), /* false */
+			shift(40), /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S63
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			shift(46), /* function_name */
+			nil,       /* ( */
+			nil,       /* ) */
+			nil,       /* () */
+			nil,       /* delimitor_param */
+			shift(54), /* doublequotes_string */
+			shift(55), /* singlequote_string */
+			shift(56), /* number */
+			shift(57), /* argument */
+			shift(58), /* true */
+			shift(59), /* false */
+			shift(60), /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S64
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			nil,       /* function_name */
+			nil,       /* ( */
+			reduce(4), /* ), reduce: Func1 */
+			nil,       /* () */
+			nil,       /* delimitor_param */
+			nil,       /* doublequotes_string */
+			nil,       /* singlequote_string */
+			nil,       /* number */
+			nil,       /* argument */
+			nil,       /* true */
+			nil,       /* false */
+			nil,       /* float */
+			reduce(4), /* operator_charactor, reduce: Func1 */
+			reduce(4), /* ?, reduce: Func1 */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S65
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			shift(93),  /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			shift(21),  /* operator_charactor */
+			reduce(31), /* ?, reduce: TernaryExp */
+			nil,        /* : */
+		},
+	},
 	actionRow{ // S66
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			shift(70), /* function_name */
+			shift(71), /* ( */
+			nil,       /* ) */
+			nil,       /* () */
+			nil,       /* delimitor_param */
+			shift(78), /* doublequotes_string */
+			shift(79), /* singlequote_string */
+			shift(80), /* number */
+			shift(81), /* argument */
+			shift(82), /* true */
+			shift(83), /* false */
+			shift(84), /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S67
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			nil,        /* operator_charactor */
+			nil,        /* ? */
+			reduce(38), /* :, reduce: TernaryParam */
+		},
+	},
+	actionRow{ // S68
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(26), /* operator_charactor, reduce: Expr */
+			reduce(26), /* ?, reduce: Expr */
+			reduce(1),  /* :, reduce: Func */
+		},
+	},
+	actionRow{ // S69
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			shift(21),  /* operator_charactor */
+			reduce(31), /* ?, reduce: TernaryExp */
+			reduce(2),  /* :, reduce: Func */
+		},
+	},
+	actionRow{ // S70
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			nil,       /* function_name */
+			shift(96), /* ( */
+			nil,       /* ) */
+			shift(97), /* () */
+			nil,       /* delimitor_param */
+			nil,       /* doublequotes_string */
+			nil,       /* singlequote_string */
+			nil,       /* number */
+			nil,       /* argument */
+			nil,       /* true */
+			nil,       /* false */
+			nil,       /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S71
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			shift(26), /* function_name */
+			shift(27), /* ( */
+			nil,       /* ) */
+			nil,       /* () */
+			nil,       /* delimitor_param */
+			shift(34), /* doublequotes_string */
+			shift(35), /* singlequote_string */
+			shift(36), /* number */
+			shift(37), /* argument */
+			shift(38), /* true */
+			shift(39), /* false */
+			shift(40), /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S72
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -1485,7 +1617,7 @@ var actionTab = actionTable{
 			reduce(22), /* :, reduce: Expr */
 		},
 	},
-	actionRow{ // S67
+	actionRow{ // S73
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -1507,7 +1639,7 @@ var actionTab = actionTable{
 			reduce(23), /* :, reduce: Expr */
 		},
 	},
-	actionRow{ // S68
+	actionRow{ // S74
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -1529,7 +1661,7 @@ var actionTab = actionTable{
 			reduce(20), /* :, reduce: Expr */
 		},
 	},
-	actionRow{ // S69
+	actionRow{ // S75
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -1551,7 +1683,7 @@ var actionTab = actionTable{
 			reduce(21), /* :, reduce: Expr */
 		},
 	},
-	actionRow{ // S70
+	actionRow{ // S76
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -1573,557 +1705,7 @@ var actionTab = actionTable{
 			reduce(24), /* :, reduce: Expr */
 		},
 	},
-	actionRow{ // S71
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			nil,        /* ) */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			reduce(13), /* operator_charactor, reduce: DoubleQString */
-			reduce(13), /* ?, reduce: DoubleQString */
-			reduce(13), /* :, reduce: DoubleQString */
-		},
-	},
-	actionRow{ // S72
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			nil,        /* ) */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			reduce(14), /* operator_charactor, reduce: SingleQString */
-			reduce(14), /* ?, reduce: SingleQString */
-			reduce(14), /* :, reduce: SingleQString */
-		},
-	},
-	actionRow{ // S73
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			nil,        /* ) */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			reduce(15), /* operator_charactor, reduce: Int */
-			reduce(15), /* ?, reduce: Int */
-			reduce(15), /* :, reduce: Int */
-		},
-	},
-	actionRow{ // S74
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			nil,        /* ) */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			reduce(16), /* operator_charactor, reduce: MappingRef */
-			reduce(16), /* ?, reduce: MappingRef */
-			reduce(16), /* :, reduce: MappingRef */
-		},
-	},
-	actionRow{ // S75
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			nil,        /* ) */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			reduce(19), /* operator_charactor, reduce: Float */
-			reduce(19), /* ?, reduce: Float */
-			reduce(19), /* :, reduce: Float */
-		},
-	},
-	actionRow{ // S76
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			nil,        /* ) */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			reduce(27), /* operator_charactor, reduce: Expr */
-			shift(90),  /* ? */
-			reduce(27), /* :, reduce: Expr */
-		},
-	},
 	actionRow{ // S77
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			nil,       /* function_name */
-			nil,       /* ( */
-			nil,       /* ) */
-			nil,       /* () */
-			nil,       /* delimitor_param */
-			nil,       /* doublequotes_string */
-			nil,       /* singlequote_string */
-			nil,       /* number */
-			nil,       /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			nil,       /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			shift(91), /* : */
-		},
-	},
-	actionRow{ // S78
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			shift(40), /* function_name */
-			nil,       /* ( */
-			nil,       /* ) */
-			nil,       /* () */
-			nil,       /* delimitor_param */
-			shift(48), /* doublequotes_string */
-			shift(49), /* singlequote_string */
-			shift(50), /* number */
-			shift(51), /* argument */
-			shift(52), /* true */
-			shift(53), /* false */
-			shift(54), /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S79
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			nil,       /* function_name */
-			nil,       /* ( */
-			reduce(4), /* ), reduce: Func1 */
-			nil,       /* () */
-			reduce(4), /* delimitor_param, reduce: Func1 */
-			nil,       /* doublequotes_string */
-			nil,       /* singlequote_string */
-			nil,       /* number */
-			nil,       /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			nil,       /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S80
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			reduce(3), /* $, reduce: Func1 */
-			nil,       /* function_name */
-			nil,       /* ( */
-			nil,       /* ) */
-			nil,       /* () */
-			nil,       /* delimitor_param */
-			nil,       /* doublequotes_string */
-			nil,       /* singlequote_string */
-			nil,       /* number */
-			nil,       /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			nil,       /* float */
-			reduce(3), /* operator_charactor, reduce: Func1 */
-			reduce(3), /* ?, reduce: Func1 */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S81
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			shift(40), /* function_name */
-			nil,       /* ( */
-			nil,       /* ) */
-			nil,       /* () */
-			nil,       /* delimitor_param */
-			shift(48), /* doublequotes_string */
-			shift(49), /* singlequote_string */
-			shift(50), /* number */
-			shift(51), /* argument */
-			shift(52), /* true */
-			shift(53), /* false */
-			shift(54), /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S82
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			reduce(26), /* ), reduce: Expr */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			shift(18),  /* operator_charactor */
-			reduce(26), /* ?, reduce: Expr */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S83
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			nil,       /* function_name */
-			nil,       /* ( */
-			shift(94), /* ) */
-			nil,       /* () */
-			shift(81), /* delimitor_param */
-			nil,       /* doublequotes_string */
-			nil,       /* singlequote_string */
-			nil,       /* number */
-			nil,       /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			nil,       /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S84
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			reduce(28), /* ), reduce: Expr */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			reduce(28), /* operator_charactor, reduce: Expr */
-			reduce(28), /* ?, reduce: Expr */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S85
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			nil,       /* function_name */
-			nil,       /* ( */
-			nil,       /* ) */
-			nil,       /* () */
-			nil,       /* delimitor_param */
-			nil,       /* doublequotes_string */
-			nil,       /* singlequote_string */
-			nil,       /* number */
-			nil,       /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			nil,       /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			shift(95), /* : */
-		},
-	},
-	actionRow{ // S86
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			shift(64), /* function_name */
-			shift(65), /* ( */
-			nil,       /* ) */
-			nil,       /* () */
-			nil,       /* delimitor_param */
-			shift(71), /* doublequotes_string */
-			shift(72), /* singlequote_string */
-			shift(73), /* number */
-			shift(74), /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			shift(75), /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S87
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			shift(40), /* function_name */
-			nil,       /* ( */
-			nil,       /* ) */
-			nil,       /* () */
-			nil,       /* delimitor_param */
-			shift(48), /* doublequotes_string */
-			shift(49), /* singlequote_string */
-			shift(50), /* number */
-			shift(51), /* argument */
-			shift(52), /* true */
-			shift(53), /* false */
-			shift(54), /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S88
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			nil,       /* function_name */
-			nil,       /* ( */
-			nil,       /* ) */
-			nil,       /* () */
-			nil,       /* delimitor_param */
-			nil,       /* doublequotes_string */
-			nil,       /* singlequote_string */
-			nil,       /* number */
-			nil,       /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			nil,       /* float */
-			reduce(4), /* operator_charactor, reduce: Func1 */
-			reduce(4), /* ?, reduce: Func1 */
-			reduce(4), /* :, reduce: Func1 */
-		},
-	},
-	actionRow{ // S89
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			shift(104), /* ) */
-			nil,        /* () */
-			nil,        /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			shift(18),  /* operator_charactor */
-			reduce(30), /* ?, reduce: TernaryExp */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S90
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			shift(64), /* function_name */
-			shift(65), /* ( */
-			nil,       /* ) */
-			nil,       /* () */
-			nil,       /* delimitor_param */
-			shift(71), /* doublequotes_string */
-			shift(72), /* singlequote_string */
-			shift(73), /* number */
-			shift(74), /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			shift(75), /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S91
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			shift(4),  /* function_name */
-			shift(5),  /* ( */
-			nil,       /* ) */
-			nil,       /* () */
-			nil,       /* delimitor_param */
-			shift(11), /* doublequotes_string */
-			shift(12), /* singlequote_string */
-			shift(13), /* number */
-			shift(14), /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			shift(15), /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S92
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			shift(115), /* ) */
-			nil,        /* () */
-			shift(81),  /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			nil,        /* operator_charactor */
-			nil,        /* ? */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S93
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,        /* INVALID */
-			nil,        /* $ */
-			nil,        /* function_name */
-			nil,        /* ( */
-			reduce(12), /* ), reduce: Args */
-			nil,        /* () */
-			shift(81),  /* delimitor_param */
-			nil,        /* doublequotes_string */
-			nil,        /* singlequote_string */
-			nil,        /* number */
-			nil,        /* argument */
-			nil,        /* true */
-			nil,        /* false */
-			nil,        /* float */
-			nil,        /* operator_charactor */
-			nil,        /* ? */
-			nil,        /* : */
-		},
-	},
-	actionRow{ // S94
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			nil,       /* function_name */
-			nil,       /* ( */
-			reduce(3), /* ), reduce: Func1 */
-			nil,       /* () */
-			nil,       /* delimitor_param */
-			nil,       /* doublequotes_string */
-			nil,       /* singlequote_string */
-			nil,       /* number */
-			nil,       /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			nil,       /* float */
-			reduce(3), /* operator_charactor, reduce: Func1 */
-			reduce(3), /* ?, reduce: Func1 */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S95
-		canRecover: false,
-		actions: [numSymbols]action{
-			nil,       /* INVALID */
-			nil,       /* $ */
-			shift(23), /* function_name */
-			shift(24), /* ( */
-			nil,       /* ) */
-			nil,       /* () */
-			nil,       /* delimitor_param */
-			shift(30), /* doublequotes_string */
-			shift(31), /* singlequote_string */
-			shift(32), /* number */
-			shift(33), /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			shift(34), /* float */
-			nil,       /* operator_charactor */
-			nil,       /* ? */
-			nil,       /* : */
-		},
-	},
-	actionRow{ // S96
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2145,7 +1727,7 @@ var actionTab = actionTable{
 			reduce(25), /* :, reduce: Expr */
 		},
 	},
-	actionRow{ // S97
+	actionRow{ // S78
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2162,12 +1744,628 @@ var actionTab = actionTable{
 			nil,        /* true */
 			nil,        /* false */
 			nil,        /* float */
-			shift(18),  /* operator_charactor */
+			reduce(13), /* operator_charactor, reduce: DoubleQString */
+			reduce(13), /* ?, reduce: DoubleQString */
+			reduce(13), /* :, reduce: DoubleQString */
+		},
+	},
+	actionRow{ // S79
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(14), /* operator_charactor, reduce: SingleQString */
+			reduce(14), /* ?, reduce: SingleQString */
+			reduce(14), /* :, reduce: SingleQString */
+		},
+	},
+	actionRow{ // S80
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(15), /* operator_charactor, reduce: Int */
+			reduce(15), /* ?, reduce: Int */
+			reduce(15), /* :, reduce: Int */
+		},
+	},
+	actionRow{ // S81
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(16), /* operator_charactor, reduce: MappingRef */
+			reduce(16), /* ?, reduce: MappingRef */
+			reduce(16), /* :, reduce: MappingRef */
+		},
+	},
+	actionRow{ // S82
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(17), /* operator_charactor, reduce: Bool */
+			reduce(17), /* ?, reduce: Bool */
+			reduce(17), /* :, reduce: Bool */
+		},
+	},
+	actionRow{ // S83
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(18), /* operator_charactor, reduce: Bool */
+			reduce(18), /* ?, reduce: Bool */
+			reduce(18), /* :, reduce: Bool */
+		},
+	},
+	actionRow{ // S84
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(19), /* operator_charactor, reduce: Float */
+			reduce(19), /* ?, reduce: Float */
+			reduce(19), /* :, reduce: Float */
+		},
+	},
+	actionRow{ // S85
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(28), /* operator_charactor, reduce: Expr */
+			shift(99),  /* ? */
+			reduce(28), /* :, reduce: Expr */
+		},
+	},
+	actionRow{ // S86
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			nil,        /* operator_charactor */
+			nil,        /* ? */
+			shift(100), /* : */
+		},
+	},
+	actionRow{ // S87
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			shift(46), /* function_name */
+			nil,       /* ( */
+			nil,       /* ) */
+			nil,       /* () */
+			nil,       /* delimitor_param */
+			shift(54), /* doublequotes_string */
+			shift(55), /* singlequote_string */
+			shift(56), /* number */
+			shift(57), /* argument */
+			shift(58), /* true */
+			shift(59), /* false */
+			shift(60), /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S88
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			nil,       /* function_name */
+			nil,       /* ( */
+			reduce(4), /* ), reduce: Func1 */
+			nil,       /* () */
+			reduce(4), /* delimitor_param, reduce: Func1 */
+			nil,       /* doublequotes_string */
+			nil,       /* singlequote_string */
+			nil,       /* number */
+			nil,       /* argument */
+			nil,       /* true */
+			nil,       /* false */
+			nil,       /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S89
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			reduce(3), /* $, reduce: Func1 */
+			nil,       /* function_name */
+			nil,       /* ( */
+			nil,       /* ) */
+			nil,       /* () */
+			nil,       /* delimitor_param */
+			nil,       /* doublequotes_string */
+			nil,       /* singlequote_string */
+			nil,       /* number */
+			nil,       /* argument */
+			nil,       /* true */
+			nil,       /* false */
+			nil,       /* float */
+			reduce(3), /* operator_charactor, reduce: Func1 */
+			reduce(3), /* ?, reduce: Func1 */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S90
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			shift(46), /* function_name */
+			nil,       /* ( */
+			nil,       /* ) */
+			nil,       /* () */
+			nil,       /* delimitor_param */
+			shift(54), /* doublequotes_string */
+			shift(55), /* singlequote_string */
+			shift(56), /* number */
+			shift(57), /* argument */
+			shift(58), /* true */
+			shift(59), /* false */
+			shift(60), /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S91
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(27), /* ), reduce: Expr */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			shift(21),  /* operator_charactor */
+			reduce(27), /* ?, reduce: Expr */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S92
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			shift(103), /* ) */
+			nil,        /* () */
+			shift(90),  /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			nil,        /* operator_charactor */
+			nil,        /* ? */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S93
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(29), /* ), reduce: Expr */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(29), /* operator_charactor, reduce: Expr */
+			reduce(29), /* ?, reduce: Expr */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S94
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			nil,        /* operator_charactor */
+			nil,        /* ? */
+			shift(104), /* : */
+		},
+	},
+	actionRow{ // S95
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			shift(70), /* function_name */
+			shift(71), /* ( */
+			nil,       /* ) */
+			nil,       /* () */
+			nil,       /* delimitor_param */
+			shift(78), /* doublequotes_string */
+			shift(79), /* singlequote_string */
+			shift(80), /* number */
+			shift(81), /* argument */
+			shift(82), /* true */
+			shift(83), /* false */
+			shift(84), /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S96
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			shift(46), /* function_name */
+			nil,       /* ( */
+			nil,       /* ) */
+			nil,       /* () */
+			nil,       /* delimitor_param */
+			shift(54), /* doublequotes_string */
+			shift(55), /* singlequote_string */
+			shift(56), /* number */
+			shift(57), /* argument */
+			shift(58), /* true */
+			shift(59), /* false */
+			shift(60), /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S97
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			nil,       /* function_name */
+			nil,       /* ( */
+			nil,       /* ) */
+			nil,       /* () */
+			nil,       /* delimitor_param */
+			nil,       /* doublequotes_string */
+			nil,       /* singlequote_string */
+			nil,       /* number */
+			nil,       /* argument */
+			nil,       /* true */
+			nil,       /* false */
+			nil,       /* float */
+			reduce(4), /* operator_charactor, reduce: Func1 */
+			reduce(4), /* ?, reduce: Func1 */
+			reduce(4), /* :, reduce: Func1 */
+		},
+	},
+	actionRow{ // S98
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			shift(113), /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			shift(21),  /* operator_charactor */
+			reduce(31), /* ?, reduce: TernaryExp */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S99
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			shift(70), /* function_name */
+			shift(71), /* ( */
+			nil,       /* ) */
+			nil,       /* () */
+			nil,       /* delimitor_param */
+			shift(78), /* doublequotes_string */
+			shift(79), /* singlequote_string */
+			shift(80), /* number */
+			shift(81), /* argument */
+			shift(82), /* true */
+			shift(83), /* false */
+			shift(84), /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S100
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			shift(4),  /* function_name */
+			shift(5),  /* ( */
+			nil,       /* ) */
+			nil,       /* () */
+			nil,       /* delimitor_param */
+			shift(12), /* doublequotes_string */
+			shift(13), /* singlequote_string */
+			shift(14), /* number */
+			shift(15), /* argument */
+			shift(16), /* true */
+			shift(17), /* false */
+			shift(18), /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S101
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			shift(124), /* ) */
+			nil,        /* () */
+			shift(90),  /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			nil,        /* operator_charactor */
+			nil,        /* ? */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S102
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			reduce(12), /* ), reduce: Args */
+			nil,        /* () */
+			shift(90),  /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			nil,        /* operator_charactor */
+			nil,        /* ? */
+			nil,        /* : */
+		},
+	},
+	actionRow{ // S103
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			nil,       /* function_name */
+			nil,       /* ( */
+			reduce(3), /* ), reduce: Func1 */
+			nil,       /* () */
+			nil,       /* delimitor_param */
+			nil,       /* doublequotes_string */
+			nil,       /* singlequote_string */
+			nil,       /* number */
+			nil,       /* argument */
+			nil,       /* true */
+			nil,       /* false */
+			nil,       /* float */
+			reduce(3), /* operator_charactor, reduce: Func1 */
+			reduce(3), /* ?, reduce: Func1 */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S104
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,       /* INVALID */
+			nil,       /* $ */
+			shift(26), /* function_name */
+			shift(27), /* ( */
+			nil,       /* ) */
+			nil,       /* () */
+			nil,       /* delimitor_param */
+			shift(34), /* doublequotes_string */
+			shift(35), /* singlequote_string */
+			shift(36), /* number */
+			shift(37), /* argument */
+			shift(38), /* true */
+			shift(39), /* false */
+			shift(40), /* float */
+			nil,       /* operator_charactor */
+			nil,       /* ? */
+			nil,       /* : */
+		},
+	},
+	actionRow{ // S105
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			reduce(26), /* operator_charactor, reduce: Expr */
 			reduce(26), /* ?, reduce: Expr */
 			reduce(26), /* :, reduce: Expr */
 		},
 	},
-	actionRow{ // S98
+	actionRow{ // S106
+		canRecover: false,
+		actions: [numSymbols]action{
+			nil,        /* INVALID */
+			nil,        /* $ */
+			nil,        /* function_name */
+			nil,        /* ( */
+			nil,        /* ) */
+			nil,        /* () */
+			nil,        /* delimitor_param */
+			nil,        /* doublequotes_string */
+			nil,        /* singlequote_string */
+			nil,        /* number */
+			nil,        /* argument */
+			nil,        /* true */
+			nil,        /* false */
+			nil,        /* float */
+			shift(21),  /* operator_charactor */
+			reduce(27), /* ?, reduce: Expr */
+			reduce(27), /* :, reduce: Expr */
+		},
+	},
+	actionRow{ // S107
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2189,7 +2387,7 @@ var actionTab = actionTable{
 			reduce(22), /* :, reduce: Expr */
 		},
 	},
-	actionRow{ // S99
+	actionRow{ // S108
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2211,7 +2409,7 @@ var actionTab = actionTable{
 			reduce(23), /* :, reduce: Expr */
 		},
 	},
-	actionRow{ // S100
+	actionRow{ // S109
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2233,7 +2431,7 @@ var actionTab = actionTable{
 			reduce(20), /* :, reduce: Expr */
 		},
 	},
-	actionRow{ // S101
+	actionRow{ // S110
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2255,7 +2453,7 @@ var actionTab = actionTable{
 			reduce(21), /* :, reduce: Expr */
 		},
 	},
-	actionRow{ // S102
+	actionRow{ // S111
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2272,21 +2470,21 @@ var actionTab = actionTable{
 			nil,        /* true */
 			nil,        /* false */
 			nil,        /* float */
-			reduce(24), /* operator_charactor, reduce: Expr */
-			reduce(24), /* ?, reduce: Expr */
-			reduce(24), /* :, reduce: Expr */
+			reduce(25), /* operator_charactor, reduce: Expr */
+			reduce(25), /* ?, reduce: Expr */
+			reduce(25), /* :, reduce: Expr */
 		},
 	},
-	actionRow{ // S103
+	actionRow{ // S112
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
 			nil,        /* $ */
 			nil,        /* function_name */
 			nil,        /* ( */
-			shift(125), /* ) */
+			shift(134), /* ) */
 			nil,        /* () */
-			shift(81),  /* delimitor_param */
+			shift(90),  /* delimitor_param */
 			nil,        /* doublequotes_string */
 			nil,        /* singlequote_string */
 			nil,        /* number */
@@ -2299,7 +2497,7 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S104
+	actionRow{ // S113
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2316,12 +2514,12 @@ var actionTab = actionTable{
 			nil,        /* true */
 			nil,        /* false */
 			nil,        /* float */
-			reduce(28), /* operator_charactor, reduce: Expr */
-			reduce(28), /* ?, reduce: Expr */
-			reduce(28), /* :, reduce: Expr */
+			reduce(29), /* operator_charactor, reduce: Expr */
+			reduce(29), /* ?, reduce: Expr */
+			reduce(29), /* :, reduce: Expr */
 		},
 	},
-	actionRow{ // S105
+	actionRow{ // S114
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2340,14 +2538,14 @@ var actionTab = actionTable{
 			nil,        /* float */
 			nil,        /* operator_charactor */
 			nil,        /* ? */
-			shift(126), /* : */
+			shift(135), /* : */
 		},
 	},
-	actionRow{ // S106
+	actionRow{ // S115
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
-			reduce(37), /* $, reduce: TernaryParam */
+			reduce(38), /* $, reduce: TernaryParam */
 			nil,        /* function_name */
 			nil,        /* ( */
 			nil,        /* ) */
@@ -2360,12 +2558,12 @@ var actionTab = actionTable{
 			nil,        /* true */
 			nil,        /* false */
 			nil,        /* float */
-			reduce(37), /* operator_charactor, reduce: TernaryParam */
-			reduce(37), /* ?, reduce: TernaryParam */
+			reduce(38), /* operator_charactor, reduce: TernaryParam */
+			reduce(38), /* ?, reduce: TernaryParam */
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S107
+	actionRow{ // S116
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       /* INVALID */
@@ -2387,7 +2585,7 @@ var actionTab = actionTable{
 			nil,       /* : */
 		},
 	},
-	actionRow{ // S108
+	actionRow{ // S117
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       /* INVALID */
@@ -2404,12 +2602,12 @@ var actionTab = actionTable{
 			nil,       /* true */
 			nil,       /* false */
 			nil,       /* float */
-			shift(18), /* operator_charactor */
+			shift(21), /* operator_charactor */
 			reduce(2), /* ?, reduce: Func */
 			nil,       /* : */
 		},
 	},
-	actionRow{ // S109
+	actionRow{ // S118
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2431,7 +2629,7 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S110
+	actionRow{ // S119
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2453,7 +2651,7 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S111
+	actionRow{ // S120
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2475,7 +2673,7 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S112
+	actionRow{ // S121
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2497,11 +2695,11 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S113
+	actionRow{ // S122
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
-			reduce(24), /* $, reduce: Expr */
+			reduce(25), /* $, reduce: Expr */
 			nil,        /* function_name */
 			nil,        /* ( */
 			nil,        /* ) */
@@ -2514,16 +2712,16 @@ var actionTab = actionTable{
 			nil,        /* true */
 			nil,        /* false */
 			nil,        /* float */
-			reduce(24), /* operator_charactor, reduce: Expr */
-			reduce(24), /* ?, reduce: Expr */
+			reduce(25), /* operator_charactor, reduce: Expr */
+			reduce(25), /* ?, reduce: Expr */
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S114
+	actionRow{ // S123
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
-			reduce(31), /* $, reduce: TernaryExp */
+			reduce(32), /* $, reduce: TernaryExp */
 			nil,        /* function_name */
 			nil,        /* ( */
 			nil,        /* ) */
@@ -2536,12 +2734,12 @@ var actionTab = actionTable{
 			nil,        /* true */
 			nil,        /* false */
 			nil,        /* float */
-			reduce(31), /* operator_charactor, reduce: TernaryExp */
-			reduce(31), /* ?, reduce: TernaryExp */
+			reduce(32), /* operator_charactor, reduce: TernaryExp */
+			reduce(32), /* ?, reduce: TernaryExp */
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S115
+	actionRow{ // S124
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       /* INVALID */
@@ -2563,14 +2761,14 @@ var actionTab = actionTable{
 			nil,       /* : */
 		},
 	},
-	actionRow{ // S116
+	actionRow{ // S125
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
 			nil,        /* $ */
 			nil,        /* function_name */
 			nil,        /* ( */
-			reduce(37), /* ), reduce: TernaryParam */
+			reduce(38), /* ), reduce: TernaryParam */
 			nil,        /* () */
 			nil,        /* delimitor_param */
 			nil,        /* doublequotes_string */
@@ -2580,12 +2778,12 @@ var actionTab = actionTable{
 			nil,        /* true */
 			nil,        /* false */
 			nil,        /* float */
-			reduce(37), /* operator_charactor, reduce: TernaryParam */
-			reduce(37), /* ?, reduce: TernaryParam */
+			reduce(38), /* operator_charactor, reduce: TernaryParam */
+			reduce(38), /* ?, reduce: TernaryParam */
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S117
+	actionRow{ // S126
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       /* INVALID */
@@ -2607,7 +2805,7 @@ var actionTab = actionTable{
 			nil,       /* : */
 		},
 	},
-	actionRow{ // S118
+	actionRow{ // S127
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       /* INVALID */
@@ -2624,12 +2822,12 @@ var actionTab = actionTable{
 			nil,       /* true */
 			nil,       /* false */
 			nil,       /* float */
-			shift(18), /* operator_charactor */
+			shift(21), /* operator_charactor */
 			reduce(2), /* ?, reduce: Func */
 			nil,       /* : */
 		},
 	},
-	actionRow{ // S119
+	actionRow{ // S128
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2651,7 +2849,7 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S120
+	actionRow{ // S129
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2673,7 +2871,7 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S121
+	actionRow{ // S130
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2695,7 +2893,7 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S122
+	actionRow{ // S131
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2717,14 +2915,14 @@ var actionTab = actionTable{
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S123
+	actionRow{ // S132
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
 			nil,        /* $ */
 			nil,        /* function_name */
 			nil,        /* ( */
-			reduce(24), /* ), reduce: Expr */
+			reduce(25), /* ), reduce: Expr */
 			nil,        /* () */
 			nil,        /* delimitor_param */
 			nil,        /* doublequotes_string */
@@ -2734,19 +2932,19 @@ var actionTab = actionTable{
 			nil,        /* true */
 			nil,        /* false */
 			nil,        /* float */
-			reduce(24), /* operator_charactor, reduce: Expr */
-			reduce(24), /* ?, reduce: Expr */
+			reduce(25), /* operator_charactor, reduce: Expr */
+			reduce(25), /* ?, reduce: Expr */
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S124
+	actionRow{ // S133
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
 			nil,        /* $ */
 			nil,        /* function_name */
 			nil,        /* ( */
-			reduce(31), /* ), reduce: TernaryExp */
+			reduce(32), /* ), reduce: TernaryExp */
 			nil,        /* () */
 			nil,        /* delimitor_param */
 			nil,        /* doublequotes_string */
@@ -2756,12 +2954,12 @@ var actionTab = actionTable{
 			nil,        /* true */
 			nil,        /* false */
 			nil,        /* float */
-			reduce(31), /* operator_charactor, reduce: TernaryExp */
-			reduce(31), /* ?, reduce: TernaryExp */
+			reduce(32), /* operator_charactor, reduce: TernaryExp */
+			reduce(32), /* ?, reduce: TernaryExp */
 			nil,        /* : */
 		},
 	},
-	actionRow{ // S125
+	actionRow{ // S134
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       /* INVALID */
@@ -2783,29 +2981,29 @@ var actionTab = actionTable{
 			reduce(3), /* :, reduce: Func1 */
 		},
 	},
-	actionRow{ // S126
+	actionRow{ // S135
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       /* INVALID */
 			nil,       /* $ */
-			shift(64), /* function_name */
-			shift(65), /* ( */
+			shift(70), /* function_name */
+			shift(71), /* ( */
 			nil,       /* ) */
 			nil,       /* () */
 			nil,       /* delimitor_param */
-			shift(71), /* doublequotes_string */
-			shift(72), /* singlequote_string */
-			shift(73), /* number */
-			shift(74), /* argument */
-			nil,       /* true */
-			nil,       /* false */
-			shift(75), /* float */
+			shift(78), /* doublequotes_string */
+			shift(79), /* singlequote_string */
+			shift(80), /* number */
+			shift(81), /* argument */
+			shift(82), /* true */
+			shift(83), /* false */
+			shift(84), /* float */
 			nil,       /* operator_charactor */
 			nil,       /* ? */
 			nil,       /* : */
 		},
 	},
-	actionRow{ // S127
+	actionRow{ // S136
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2822,12 +3020,12 @@ var actionTab = actionTable{
 			nil,        /* true */
 			nil,        /* false */
 			nil,        /* float */
-			reduce(37), /* operator_charactor, reduce: TernaryParam */
-			reduce(37), /* ?, reduce: TernaryParam */
-			reduce(37), /* :, reduce: TernaryParam */
+			reduce(38), /* operator_charactor, reduce: TernaryParam */
+			reduce(38), /* ?, reduce: TernaryParam */
+			reduce(38), /* :, reduce: TernaryParam */
 		},
 	},
-	actionRow{ // S128
+	actionRow{ // S137
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       /* INVALID */
@@ -2849,7 +3047,7 @@ var actionTab = actionTable{
 			reduce(1), /* :, reduce: Func */
 		},
 	},
-	actionRow{ // S129
+	actionRow{ // S138
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       /* INVALID */
@@ -2866,12 +3064,12 @@ var actionTab = actionTable{
 			nil,       /* true */
 			nil,       /* false */
 			nil,       /* float */
-			shift(18), /* operator_charactor */
+			shift(21), /* operator_charactor */
 			reduce(2), /* ?, reduce: Func */
 			reduce(2), /* :, reduce: Func */
 		},
 	},
-	actionRow{ // S130
+	actionRow{ // S139
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2893,7 +3091,7 @@ var actionTab = actionTable{
 			reduce(22), /* :, reduce: Expr */
 		},
 	},
-	actionRow{ // S131
+	actionRow{ // S140
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2915,7 +3113,7 @@ var actionTab = actionTable{
 			reduce(23), /* :, reduce: Expr */
 		},
 	},
-	actionRow{ // S132
+	actionRow{ // S141
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2937,7 +3135,7 @@ var actionTab = actionTable{
 			reduce(20), /* :, reduce: Expr */
 		},
 	},
-	actionRow{ // S133
+	actionRow{ // S142
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2959,7 +3157,7 @@ var actionTab = actionTable{
 			reduce(21), /* :, reduce: Expr */
 		},
 	},
-	actionRow{ // S134
+	actionRow{ // S143
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2976,12 +3174,12 @@ var actionTab = actionTable{
 			nil,        /* true */
 			nil,        /* false */
 			nil,        /* float */
-			reduce(24), /* operator_charactor, reduce: Expr */
-			reduce(24), /* ?, reduce: Expr */
-			reduce(24), /* :, reduce: Expr */
+			reduce(25), /* operator_charactor, reduce: Expr */
+			reduce(25), /* ?, reduce: Expr */
+			reduce(25), /* :, reduce: Expr */
 		},
 	},
-	actionRow{ // S135
+	actionRow{ // S144
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        /* INVALID */
@@ -2998,9 +3196,9 @@ var actionTab = actionTable{
 			nil,        /* true */
 			nil,        /* false */
 			nil,        /* float */
-			reduce(31), /* operator_charactor, reduce: TernaryExp */
-			reduce(31), /* ?, reduce: TernaryExp */
-			reduce(31), /* :, reduce: TernaryExp */
+			reduce(32), /* operator_charactor, reduce: TernaryExp */
+			reduce(32), /* ?, reduce: TernaryExp */
+			reduce(32), /* :, reduce: TernaryExp */
 		},
 	},
 }

--- a/core/mapper/exprmapper/expression/gocc/parser/gototable.go
+++ b/core/mapper/exprmapper/expression/gocc/parser/gototable.go
@@ -18,12 +18,12 @@ var gotoTab = gotoTable{
 		6,  // DoubleQString
 		7,  // SingleQString
 		8,  // Int
-		10, // MappingRef
-		-1, // Bool
+		11, // MappingRef
+		10, // Bool
 		9,  // Float
 		3,  // Expr
 		-1, // Operator
-		16, // TernaryExp
+		19, // TernaryExp
 		-1, // TernaryParam
 	},
 	gotoRow{ // S1
@@ -70,7 +70,7 @@ var gotoTab = gotoTable{
 		-1, // Bool
 		-1, // Float
 		-1, // Expr
-		17, // Operator
+		20, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
 	},
@@ -93,17 +93,17 @@ var gotoTab = gotoTable{
 	gotoRow{ // S5
 		-1, // S'
 		-1, // Func
-		21, // Func1
+		24, // Func1
 		-1, // Args
-		25, // DoubleQString
-		26, // SingleQString
-		27, // Int
-		29, // MappingRef
-		-1, // Bool
-		28, // Float
-		22, // Expr
+		28, // DoubleQString
+		29, // SingleQString
+		30, // Int
+		33, // MappingRef
+		32, // Bool
+		31, // Float
+		25, // Expr
 		-1, // Operator
-		35, // TernaryExp
+		41, // TernaryExp
 		-1, // TernaryParam
 	},
 	gotoRow{ // S6
@@ -285,17 +285,17 @@ var gotoTab = gotoTable{
 	gotoRow{ // S17
 		-1, // S'
 		-1, // Func
-		37, // Func1
+		-1, // Func1
 		-1, // Args
-		6,  // DoubleQString
-		7,  // SingleQString
-		8,  // Int
-		10, // MappingRef
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
 		-1, // Bool
-		9,  // Float
-		38, // Expr
+		-1, // Float
+		-1, // Expr
 		-1, // Operator
-		16, // TernaryExp
+		-1, // TernaryExp
 		-1, // TernaryParam
 	},
 	gotoRow{ // S18
@@ -317,22 +317,6 @@ var gotoTab = gotoTable{
 	gotoRow{ // S19
 		-1, // S'
 		-1, // Func
-		39, // Func1
-		41, // Args
-		42, // DoubleQString
-		43, // SingleQString
-		44, // Int
-		47, // MappingRef
-		46, // Bool
-		45, // Float
-		-1, // Expr
-		-1, // Operator
-		-1, // TernaryExp
-		-1, // TernaryParam
-	},
-	gotoRow{ // S20
-		-1, // S'
-		-1, // Func
 		-1, // Func1
 		-1, // Args
 		-1, // DoubleQString
@@ -344,6 +328,22 @@ var gotoTab = gotoTable{
 		-1, // Expr
 		-1, // Operator
 		-1, // TernaryExp
+		-1, // TernaryParam
+	},
+	gotoRow{ // S20
+		-1, // S'
+		-1, // Func
+		43, // Func1
+		-1, // Args
+		6,  // DoubleQString
+		7,  // SingleQString
+		8,  // Int
+		11, // MappingRef
+		10, // Bool
+		9,  // Float
+		44, // Expr
+		-1, // Operator
+		19, // TernaryExp
 		-1, // TernaryParam
 	},
 	gotoRow{ // S21
@@ -365,16 +365,16 @@ var gotoTab = gotoTable{
 	gotoRow{ // S22
 		-1, // S'
 		-1, // Func
-		-1, // Func1
-		-1, // Args
-		-1, // DoubleQString
-		-1, // SingleQString
-		-1, // Int
-		-1, // MappingRef
-		-1, // Bool
-		-1, // Float
+		45, // Func1
+		47, // Args
+		48, // DoubleQString
+		49, // SingleQString
+		50, // Int
+		53, // MappingRef
+		52, // Bool
+		51, // Float
 		-1, // Expr
-		56, // Operator
+		-1, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
 	},
@@ -397,17 +397,17 @@ var gotoTab = gotoTable{
 	gotoRow{ // S24
 		-1, // S'
 		-1, // Func
-		21, // Func1
+		-1, // Func1
 		-1, // Args
-		25, // DoubleQString
-		26, // SingleQString
-		27, // Int
-		29, // MappingRef
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
 		-1, // Bool
-		28, // Float
-		59, // Expr
+		-1, // Float
+		-1, // Expr
 		-1, // Operator
-		35, // TernaryExp
+		-1, // TernaryExp
 		-1, // TernaryParam
 	},
 	gotoRow{ // S25
@@ -422,7 +422,7 @@ var gotoTab = gotoTable{
 		-1, // Bool
 		-1, // Float
 		-1, // Expr
-		-1, // Operator
+		62, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
 	},
@@ -445,17 +445,17 @@ var gotoTab = gotoTable{
 	gotoRow{ // S27
 		-1, // S'
 		-1, // Func
-		-1, // Func1
+		24, // Func1
 		-1, // Args
-		-1, // DoubleQString
-		-1, // SingleQString
-		-1, // Int
-		-1, // MappingRef
-		-1, // Bool
-		-1, // Float
-		-1, // Expr
+		28, // DoubleQString
+		29, // SingleQString
+		30, // Int
+		33, // MappingRef
+		32, // Bool
+		31, // Float
+		65, // Expr
 		-1, // Operator
-		-1, // TernaryExp
+		41, // TernaryExp
 		-1, // TernaryParam
 	},
 	gotoRow{ // S28
@@ -588,19 +588,19 @@ var gotoTab = gotoTable{
 	},
 	gotoRow{ // S36
 		-1, // S'
-		61, // Func
-		62, // Func1
+		-1, // Func
+		-1, // Func1
 		-1, // Args
-		66, // DoubleQString
-		67, // SingleQString
-		68, // Int
-		70, // MappingRef
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
 		-1, // Bool
-		69, // Float
-		63, // Expr
+		-1, // Float
+		-1, // Expr
 		-1, // Operator
-		76, // TernaryExp
-		77, // TernaryParam
+		-1, // TernaryExp
+		-1, // TernaryParam
 	},
 	gotoRow{ // S37
 		-1, // S'
@@ -630,7 +630,7 @@ var gotoTab = gotoTable{
 		-1, // Bool
 		-1, // Float
 		-1, // Expr
-		17, // Operator
+		-1, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
 	},
@@ -684,19 +684,19 @@ var gotoTab = gotoTable{
 	},
 	gotoRow{ // S42
 		-1, // S'
-		-1, // Func
-		-1, // Func1
+		67, // Func
+		68, // Func1
 		-1, // Args
-		-1, // DoubleQString
-		-1, // SingleQString
-		-1, // Int
-		-1, // MappingRef
-		-1, // Bool
-		-1, // Float
-		-1, // Expr
+		72, // DoubleQString
+		73, // SingleQString
+		74, // Int
+		77, // MappingRef
+		76, // Bool
+		75, // Float
+		69, // Expr
 		-1, // Operator
-		-1, // TernaryExp
-		-1, // TernaryParam
+		85, // TernaryExp
+		86, // TernaryParam
 	},
 	gotoRow{ // S43
 		-1, // S'
@@ -726,7 +726,7 @@ var gotoTab = gotoTable{
 		-1, // Bool
 		-1, // Float
 		-1, // Expr
-		-1, // Operator
+		20, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
 	},
@@ -909,30 +909,30 @@ var gotoTab = gotoTable{
 	gotoRow{ // S56
 		-1, // S'
 		-1, // Func
-		21, // Func1
+		-1, // Func1
 		-1, // Args
-		25, // DoubleQString
-		26, // SingleQString
-		27, // Int
-		29, // MappingRef
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
 		-1, // Bool
-		28, // Float
-		82, // Expr
+		-1, // Float
+		-1, // Expr
 		-1, // Operator
-		35, // TernaryExp
+		-1, // TernaryExp
 		-1, // TernaryParam
 	},
 	gotoRow{ // S57
 		-1, // S'
 		-1, // Func
-		39, // Func1
-		83, // Args
-		42, // DoubleQString
-		43, // SingleQString
-		44, // Int
-		47, // MappingRef
-		46, // Bool
-		45, // Float
+		-1, // Func1
+		-1, // Args
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
+		-1, // Bool
+		-1, // Float
 		-1, // Expr
 		-1, // Operator
 		-1, // TernaryExp
@@ -966,25 +966,25 @@ var gotoTab = gotoTable{
 		-1, // Bool
 		-1, // Float
 		-1, // Expr
-		56, // Operator
+		-1, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
 	},
 	gotoRow{ // S60
 		-1, // S'
-		61, // Func
-		62, // Func1
+		-1, // Func
+		-1, // Func1
 		-1, // Args
-		66, // DoubleQString
-		67, // SingleQString
-		68, // Int
-		70, // MappingRef
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
 		-1, // Bool
-		69, // Float
-		63, // Expr
+		-1, // Float
+		-1, // Expr
 		-1, // Operator
-		76, // TernaryExp
-		85, // TernaryParam
+		-1, // TernaryExp
+		-1, // TernaryParam
 	},
 	gotoRow{ // S61
 		-1, // S'
@@ -1005,32 +1005,32 @@ var gotoTab = gotoTable{
 	gotoRow{ // S62
 		-1, // S'
 		-1, // Func
-		-1, // Func1
+		24, // Func1
 		-1, // Args
-		-1, // DoubleQString
-		-1, // SingleQString
-		-1, // Int
-		-1, // MappingRef
-		-1, // Bool
-		-1, // Float
-		-1, // Expr
+		28, // DoubleQString
+		29, // SingleQString
+		30, // Int
+		33, // MappingRef
+		32, // Bool
+		31, // Float
+		91, // Expr
 		-1, // Operator
-		-1, // TernaryExp
+		41, // TernaryExp
 		-1, // TernaryParam
 	},
 	gotoRow{ // S63
 		-1, // S'
 		-1, // Func
-		-1, // Func1
-		-1, // Args
-		-1, // DoubleQString
-		-1, // SingleQString
-		-1, // Int
-		-1, // MappingRef
-		-1, // Bool
-		-1, // Float
+		45, // Func1
+		92, // Args
+		48, // DoubleQString
+		49, // SingleQString
+		50, // Int
+		53, // MappingRef
+		52, // Bool
+		51, // Float
 		-1, // Expr
-		86, // Operator
+		-1, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
 	},
@@ -1053,22 +1053,6 @@ var gotoTab = gotoTable{
 	gotoRow{ // S65
 		-1, // S'
 		-1, // Func
-		21, // Func1
-		-1, // Args
-		25, // DoubleQString
-		26, // SingleQString
-		27, // Int
-		29, // MappingRef
-		-1, // Bool
-		28, // Float
-		89, // Expr
-		-1, // Operator
-		35, // TernaryExp
-		-1, // TernaryParam
-	},
-	gotoRow{ // S66
-		-1, // S'
-		-1, // Func
 		-1, // Func1
 		-1, // Args
 		-1, // DoubleQString
@@ -1078,9 +1062,25 @@ var gotoTab = gotoTable{
 		-1, // Bool
 		-1, // Float
 		-1, // Expr
-		-1, // Operator
+		62, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
+	},
+	gotoRow{ // S66
+		-1, // S'
+		67, // Func
+		68, // Func1
+		-1, // Args
+		72, // DoubleQString
+		73, // SingleQString
+		74, // Int
+		77, // MappingRef
+		76, // Bool
+		75, // Float
+		69, // Expr
+		-1, // Operator
+		85, // TernaryExp
+		94, // TernaryParam
 	},
 	gotoRow{ // S67
 		-1, // S'
@@ -1126,7 +1126,7 @@ var gotoTab = gotoTable{
 		-1, // Bool
 		-1, // Float
 		-1, // Expr
-		-1, // Operator
+		95, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
 	},
@@ -1149,17 +1149,17 @@ var gotoTab = gotoTable{
 	gotoRow{ // S71
 		-1, // S'
 		-1, // Func
-		-1, // Func1
+		24, // Func1
 		-1, // Args
-		-1, // DoubleQString
-		-1, // SingleQString
-		-1, // Int
-		-1, // MappingRef
-		-1, // Bool
-		-1, // Float
-		-1, // Expr
+		28, // DoubleQString
+		29, // SingleQString
+		30, // Int
+		33, // MappingRef
+		32, // Bool
+		31, // Float
+		98, // Expr
 		-1, // Operator
-		-1, // TernaryExp
+		41, // TernaryExp
 		-1, // TernaryParam
 	},
 	gotoRow{ // S72
@@ -1261,14 +1261,14 @@ var gotoTab = gotoTable{
 	gotoRow{ // S78
 		-1, // S'
 		-1, // Func
-		39, // Func1
-		92, // Args
-		42, // DoubleQString
-		43, // SingleQString
-		44, // Int
-		47, // MappingRef
-		46, // Bool
-		45, // Float
+		-1, // Func1
+		-1, // Args
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
+		-1, // Bool
+		-1, // Float
 		-1, // Expr
 		-1, // Operator
 		-1, // TernaryExp
@@ -1309,14 +1309,14 @@ var gotoTab = gotoTable{
 	gotoRow{ // S81
 		-1, // S'
 		-1, // Func
-		39, // Func1
-		93, // Args
-		42, // DoubleQString
-		43, // SingleQString
-		44, // Int
-		47, // MappingRef
-		46, // Bool
-		45, // Float
+		-1, // Func1
+		-1, // Args
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
+		-1, // Bool
+		-1, // Float
 		-1, // Expr
 		-1, // Operator
 		-1, // TernaryExp
@@ -1334,7 +1334,7 @@ var gotoTab = gotoTable{
 		-1, // Bool
 		-1, // Float
 		-1, // Expr
-		56, // Operator
+		-1, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
 	},
@@ -1387,32 +1387,32 @@ var gotoTab = gotoTable{
 		-1, // TernaryParam
 	},
 	gotoRow{ // S86
-		-1,  // S'
-		-1,  // Func
-		96,  // Func1
-		-1,  // Args
-		98,  // DoubleQString
-		99,  // SingleQString
-		100, // Int
-		102, // MappingRef
-		-1,  // Bool
-		101, // Float
-		97,  // Expr
-		-1,  // Operator
-		76,  // TernaryExp
-		-1,  // TernaryParam
+		-1, // S'
+		-1, // Func
+		-1, // Func1
+		-1, // Args
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
+		-1, // Bool
+		-1, // Float
+		-1, // Expr
+		-1, // Operator
+		-1, // TernaryExp
+		-1, // TernaryParam
 	},
 	gotoRow{ // S87
 		-1,  // S'
 		-1,  // Func
-		39,  // Func1
-		103, // Args
-		42,  // DoubleQString
-		43,  // SingleQString
-		44,  // Int
-		47,  // MappingRef
-		46,  // Bool
-		45,  // Float
+		45,  // Func1
+		101, // Args
+		48,  // DoubleQString
+		49,  // SingleQString
+		50,  // Int
+		53,  // MappingRef
+		52,  // Bool
+		51,  // Float
 		-1,  // Expr
 		-1,  // Operator
 		-1,  // TernaryExp
@@ -1446,41 +1446,41 @@ var gotoTab = gotoTable{
 		-1, // Bool
 		-1, // Float
 		-1, // Expr
-		56, // Operator
+		-1, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
 	},
 	gotoRow{ // S90
 		-1,  // S'
-		61,  // Func
-		62,  // Func1
-		-1,  // Args
-		66,  // DoubleQString
-		67,  // SingleQString
-		68,  // Int
-		70,  // MappingRef
-		-1,  // Bool
-		69,  // Float
-		63,  // Expr
+		-1,  // Func
+		45,  // Func1
+		102, // Args
+		48,  // DoubleQString
+		49,  // SingleQString
+		50,  // Int
+		53,  // MappingRef
+		52,  // Bool
+		51,  // Float
+		-1,  // Expr
 		-1,  // Operator
-		76,  // TernaryExp
-		105, // TernaryParam
+		-1,  // TernaryExp
+		-1,  // TernaryParam
 	},
 	gotoRow{ // S91
-		-1,  // S'
-		106, // Func
-		107, // Func1
-		-1,  // Args
-		109, // DoubleQString
-		110, // SingleQString
-		111, // Int
-		113, // MappingRef
-		-1,  // Bool
-		112, // Float
-		108, // Expr
-		-1,  // Operator
-		16,  // TernaryExp
-		114, // TernaryParam
+		-1, // S'
+		-1, // Func
+		-1, // Func1
+		-1, // Args
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
+		-1, // Bool
+		-1, // Float
+		-1, // Expr
+		62, // Operator
+		-1, // TernaryExp
+		-1, // TernaryParam
 	},
 	gotoRow{ // S92
 		-1, // S'
@@ -1532,35 +1532,35 @@ var gotoTab = gotoTable{
 	},
 	gotoRow{ // S95
 		-1,  // S'
-		116, // Func
-		117, // Func1
+		-1,  // Func
+		105, // Func1
 		-1,  // Args
-		119, // DoubleQString
-		120, // SingleQString
-		121, // Int
-		123, // MappingRef
-		-1,  // Bool
-		122, // Float
-		118, // Expr
+		107, // DoubleQString
+		108, // SingleQString
+		109, // Int
+		111, // MappingRef
+		76,  // Bool
+		110, // Float
+		106, // Expr
 		-1,  // Operator
-		35,  // TernaryExp
-		124, // TernaryParam
+		85,  // TernaryExp
+		-1,  // TernaryParam
 	},
 	gotoRow{ // S96
-		-1, // S'
-		-1, // Func
-		-1, // Func1
-		-1, // Args
-		-1, // DoubleQString
-		-1, // SingleQString
-		-1, // Int
-		-1, // MappingRef
-		-1, // Bool
-		-1, // Float
-		-1, // Expr
-		-1, // Operator
-		-1, // TernaryExp
-		-1, // TernaryParam
+		-1,  // S'
+		-1,  // Func
+		45,  // Func1
+		112, // Args
+		48,  // DoubleQString
+		49,  // SingleQString
+		50,  // Int
+		53,  // MappingRef
+		52,  // Bool
+		51,  // Float
+		-1,  // Expr
+		-1,  // Operator
+		-1,  // TernaryExp
+		-1,  // TernaryParam
 	},
 	gotoRow{ // S97
 		-1, // S'
@@ -1574,7 +1574,7 @@ var gotoTab = gotoTable{
 		-1, // Bool
 		-1, // Float
 		-1, // Expr
-		86, // Operator
+		-1, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
 	},
@@ -1590,41 +1590,41 @@ var gotoTab = gotoTable{
 		-1, // Bool
 		-1, // Float
 		-1, // Expr
-		-1, // Operator
+		62, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
 	},
 	gotoRow{ // S99
-		-1, // S'
-		-1, // Func
-		-1, // Func1
-		-1, // Args
-		-1, // DoubleQString
-		-1, // SingleQString
-		-1, // Int
-		-1, // MappingRef
-		-1, // Bool
-		-1, // Float
-		-1, // Expr
-		-1, // Operator
-		-1, // TernaryExp
-		-1, // TernaryParam
+		-1,  // S'
+		67,  // Func
+		68,  // Func1
+		-1,  // Args
+		72,  // DoubleQString
+		73,  // SingleQString
+		74,  // Int
+		77,  // MappingRef
+		76,  // Bool
+		75,  // Float
+		69,  // Expr
+		-1,  // Operator
+		85,  // TernaryExp
+		114, // TernaryParam
 	},
 	gotoRow{ // S100
-		-1, // S'
-		-1, // Func
-		-1, // Func1
-		-1, // Args
-		-1, // DoubleQString
-		-1, // SingleQString
-		-1, // Int
-		-1, // MappingRef
-		-1, // Bool
-		-1, // Float
-		-1, // Expr
-		-1, // Operator
-		-1, // TernaryExp
-		-1, // TernaryParam
+		-1,  // S'
+		115, // Func
+		116, // Func1
+		-1,  // Args
+		118, // DoubleQString
+		119, // SingleQString
+		120, // Int
+		122, // MappingRef
+		10,  // Bool
+		121, // Float
+		117, // Expr
+		-1,  // Operator
+		19,  // TernaryExp
+		123, // TernaryParam
 	},
 	gotoRow{ // S101
 		-1, // S'
@@ -1675,20 +1675,20 @@ var gotoTab = gotoTable{
 		-1, // TernaryParam
 	},
 	gotoRow{ // S104
-		-1, // S'
-		-1, // Func
-		-1, // Func1
-		-1, // Args
-		-1, // DoubleQString
-		-1, // SingleQString
-		-1, // Int
-		-1, // MappingRef
-		-1, // Bool
-		-1, // Float
-		-1, // Expr
-		-1, // Operator
-		-1, // TernaryExp
-		-1, // TernaryParam
+		-1,  // S'
+		125, // Func
+		126, // Func1
+		-1,  // Args
+		128, // DoubleQString
+		129, // SingleQString
+		130, // Int
+		132, // MappingRef
+		32,  // Bool
+		131, // Float
+		127, // Expr
+		-1,  // Operator
+		41,  // TernaryExp
+		133, // TernaryParam
 	},
 	gotoRow{ // S105
 		-1, // S'
@@ -1718,7 +1718,7 @@ var gotoTab = gotoTable{
 		-1, // Bool
 		-1, // Float
 		-1, // Expr
-		-1, // Operator
+		95, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
 	},
@@ -1750,7 +1750,7 @@ var gotoTab = gotoTable{
 		-1, // Bool
 		-1, // Float
 		-1, // Expr
-		17, // Operator
+		-1, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
 	},
@@ -1894,7 +1894,7 @@ var gotoTab = gotoTable{
 		-1, // Bool
 		-1, // Float
 		-1, // Expr
-		-1, // Operator
+		20, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
 	},
@@ -1910,7 +1910,7 @@ var gotoTab = gotoTable{
 		-1, // Bool
 		-1, // Float
 		-1, // Expr
-		56, // Operator
+		-1, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
 	},
@@ -2027,20 +2027,20 @@ var gotoTab = gotoTable{
 		-1, // TernaryParam
 	},
 	gotoRow{ // S126
-		-1,  // S'
-		127, // Func
-		128, // Func1
-		-1,  // Args
-		130, // DoubleQString
-		131, // SingleQString
-		132, // Int
-		134, // MappingRef
-		-1,  // Bool
-		133, // Float
-		129, // Expr
-		-1,  // Operator
-		76,  // TernaryExp
-		135, // TernaryParam
+		-1, // S'
+		-1, // Func
+		-1, // Func1
+		-1, // Args
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
+		-1, // Bool
+		-1, // Float
+		-1, // Expr
+		-1, // Operator
+		-1, // TernaryExp
+		-1, // TernaryParam
 	},
 	gotoRow{ // S127
 		-1, // S'
@@ -2054,7 +2054,7 @@ var gotoTab = gotoTable{
 		-1, // Bool
 		-1, // Float
 		-1, // Expr
-		-1, // Operator
+		62, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
 	},
@@ -2086,7 +2086,7 @@ var gotoTab = gotoTable{
 		-1, // Bool
 		-1, // Float
 		-1, // Expr
-		86, // Operator
+		-1, // Operator
 		-1, // TernaryExp
 		-1, // TernaryParam
 	},
@@ -2171,6 +2171,150 @@ var gotoTab = gotoTable{
 		-1, // TernaryParam
 	},
 	gotoRow{ // S135
+		-1,  // S'
+		136, // Func
+		137, // Func1
+		-1,  // Args
+		139, // DoubleQString
+		140, // SingleQString
+		141, // Int
+		143, // MappingRef
+		76,  // Bool
+		142, // Float
+		138, // Expr
+		-1,  // Operator
+		85,  // TernaryExp
+		144, // TernaryParam
+	},
+	gotoRow{ // S136
+		-1, // S'
+		-1, // Func
+		-1, // Func1
+		-1, // Args
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
+		-1, // Bool
+		-1, // Float
+		-1, // Expr
+		-1, // Operator
+		-1, // TernaryExp
+		-1, // TernaryParam
+	},
+	gotoRow{ // S137
+		-1, // S'
+		-1, // Func
+		-1, // Func1
+		-1, // Args
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
+		-1, // Bool
+		-1, // Float
+		-1, // Expr
+		-1, // Operator
+		-1, // TernaryExp
+		-1, // TernaryParam
+	},
+	gotoRow{ // S138
+		-1, // S'
+		-1, // Func
+		-1, // Func1
+		-1, // Args
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
+		-1, // Bool
+		-1, // Float
+		-1, // Expr
+		95, // Operator
+		-1, // TernaryExp
+		-1, // TernaryParam
+	},
+	gotoRow{ // S139
+		-1, // S'
+		-1, // Func
+		-1, // Func1
+		-1, // Args
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
+		-1, // Bool
+		-1, // Float
+		-1, // Expr
+		-1, // Operator
+		-1, // TernaryExp
+		-1, // TernaryParam
+	},
+	gotoRow{ // S140
+		-1, // S'
+		-1, // Func
+		-1, // Func1
+		-1, // Args
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
+		-1, // Bool
+		-1, // Float
+		-1, // Expr
+		-1, // Operator
+		-1, // TernaryExp
+		-1, // TernaryParam
+	},
+	gotoRow{ // S141
+		-1, // S'
+		-1, // Func
+		-1, // Func1
+		-1, // Args
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
+		-1, // Bool
+		-1, // Float
+		-1, // Expr
+		-1, // Operator
+		-1, // TernaryExp
+		-1, // TernaryParam
+	},
+	gotoRow{ // S142
+		-1, // S'
+		-1, // Func
+		-1, // Func1
+		-1, // Args
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
+		-1, // Bool
+		-1, // Float
+		-1, // Expr
+		-1, // Operator
+		-1, // TernaryExp
+		-1, // TernaryParam
+	},
+	gotoRow{ // S143
+		-1, // S'
+		-1, // Func
+		-1, // Func1
+		-1, // Args
+		-1, // DoubleQString
+		-1, // SingleQString
+		-1, // Int
+		-1, // MappingRef
+		-1, // Bool
+		-1, // Float
+		-1, // Expr
+		-1, // Operator
+		-1, // TernaryExp
+		-1, // TernaryParam
+	},
+	gotoRow{ // S144
 		-1, // S'
 		-1, // Func
 		-1, // Func1

--- a/core/mapper/exprmapper/expression/gocc/parser/parser.go
+++ b/core/mapper/exprmapper/expression/gocc/parser/parser.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	numProductions = 38
-	numStates      = 136
+	numProductions = 39
+	numStates      = 145
 	numSymbols     = 31
 )
 

--- a/core/mapper/exprmapper/expression/gocc/parser/productionstable.go
+++ b/core/mapper/exprmapper/expression/gocc/parser/productionstable.go
@@ -261,7 +261,7 @@ var productionsTable = ProdTab{
 		},
 	},
 	ProdTabEntry{
-		String: `Expr : MappingRef	<< direction.NewExpressionField(X[0]) >>`,
+		String: `Expr : Bool	<< direction.NewExpressionField(X[0]) >>`,
 		Id:         "Expr",
 		NTType:     10,
 		Index:      24,
@@ -271,7 +271,7 @@ var productionsTable = ProdTab{
 		},
 	},
 	ProdTabEntry{
-		String: `Expr : Func1	<< direction.NewExpressionField(X[0]) >>`,
+		String: `Expr : MappingRef	<< direction.NewExpressionField(X[0]) >>`,
 		Id:         "Expr",
 		NTType:     10,
 		Index:      25,
@@ -281,10 +281,20 @@ var productionsTable = ProdTab{
 		},
 	},
 	ProdTabEntry{
-		String: `Expr : Expr Operator Expr	<< direction.NewExpression(X[0], X[1], X[2]) >>`,
+		String: `Expr : Func1	<< direction.NewExpressionField(X[0]) >>`,
 		Id:         "Expr",
 		NTType:     10,
 		Index:      26,
+		NumSymbols: 1,
+		ReduceFunc: func(X []Attrib) (Attrib, error) {
+			return direction.NewExpressionField(X[0])
+		},
+	},
+	ProdTabEntry{
+		String: `Expr : Expr Operator Expr	<< direction.NewExpression(X[0], X[1], X[2]) >>`,
+		Id:         "Expr",
+		NTType:     10,
+		Index:      27,
 		NumSymbols: 3,
 		ReduceFunc: func(X []Attrib) (Attrib, error) {
 			return direction.NewExpression(X[0], X[1], X[2])
@@ -294,7 +304,7 @@ var productionsTable = ProdTab{
 		String: `Expr : TernaryExp	<<  >>`,
 		Id:         "Expr",
 		NTType:     10,
-		Index:      27,
+		Index:      28,
 		NumSymbols: 1,
 		ReduceFunc: func(X []Attrib) (Attrib, error) {
 			return X[0], nil
@@ -304,7 +314,7 @@ var productionsTable = ProdTab{
 		String: `Expr : "(" Expr ")"	<< direction.NewExpressionField(X[1]) >>`,
 		Id:         "Expr",
 		NTType:     10,
-		Index:      28,
+		Index:      29,
 		NumSymbols: 3,
 		ReduceFunc: func(X []Attrib) (Attrib, error) {
 			return direction.NewExpressionField(X[1])
@@ -314,7 +324,7 @@ var productionsTable = ProdTab{
 		String: `Operator : operator_charactor	<<  >>`,
 		Id:         "Operator",
 		NTType:     11,
-		Index:      29,
+		Index:      30,
 		NumSymbols: 1,
 		ReduceFunc: func(X []Attrib) (Attrib, error) {
 			return X[0], nil
@@ -324,7 +334,7 @@ var productionsTable = ProdTab{
 		String: `TernaryExp : Expr	<< direction.NewExpressionField(X[0]) >>`,
 		Id:         "TernaryExp",
 		NTType:     12,
-		Index:      30,
+		Index:      31,
 		NumSymbols: 1,
 		ReduceFunc: func(X []Attrib) (Attrib, error) {
 			return direction.NewExpressionField(X[0])
@@ -334,7 +344,7 @@ var productionsTable = ProdTab{
 		String: `TernaryExp : TernaryExp "?" TernaryParam ":" TernaryParam	<< direction.NewTernaryExpression(X[0], X[2], X[4]) >>`,
 		Id:         "TernaryExp",
 		NTType:     12,
-		Index:      31,
+		Index:      32,
 		NumSymbols: 5,
 		ReduceFunc: func(X []Attrib) (Attrib, error) {
 			return direction.NewTernaryExpression(X[0], X[2], X[4])
@@ -344,7 +354,7 @@ var productionsTable = ProdTab{
 		String: `TernaryParam : Int	<< direction.NewExpressionField(X[0]) >>`,
 		Id:         "TernaryParam",
 		NTType:     13,
-		Index:      32,
+		Index:      33,
 		NumSymbols: 1,
 		ReduceFunc: func(X []Attrib) (Attrib, error) {
 			return direction.NewExpressionField(X[0])
@@ -354,7 +364,7 @@ var productionsTable = ProdTab{
 		String: `TernaryParam : Float	<< direction.NewExpressionField(X[0]) >>`,
 		Id:         "TernaryParam",
 		NTType:     13,
-		Index:      33,
+		Index:      34,
 		NumSymbols: 1,
 		ReduceFunc: func(X []Attrib) (Attrib, error) {
 			return direction.NewExpressionField(X[0])
@@ -364,7 +374,7 @@ var productionsTable = ProdTab{
 		String: `TernaryParam : DoubleQString	<< direction.NewExpressionField(X[0]) >>`,
 		Id:         "TernaryParam",
 		NTType:     13,
-		Index:      34,
+		Index:      35,
 		NumSymbols: 1,
 		ReduceFunc: func(X []Attrib) (Attrib, error) {
 			return direction.NewExpressionField(X[0])
@@ -374,7 +384,7 @@ var productionsTable = ProdTab{
 		String: `TernaryParam : SingleQString	<< direction.NewExpressionField(X[0]) >>`,
 		Id:         "TernaryParam",
 		NTType:     13,
-		Index:      35,
+		Index:      36,
 		NumSymbols: 1,
 		ReduceFunc: func(X []Attrib) (Attrib, error) {
 			return direction.NewExpressionField(X[0])
@@ -384,7 +394,7 @@ var productionsTable = ProdTab{
 		String: `TernaryParam : MappingRef	<< direction.NewExpressionField(X[0]) >>`,
 		Id:         "TernaryParam",
 		NTType:     13,
-		Index:      36,
+		Index:      37,
 		NumSymbols: 1,
 		ReduceFunc: func(X []Attrib) (Attrib, error) {
 			return direction.NewExpressionField(X[0])
@@ -394,7 +404,7 @@ var productionsTable = ProdTab{
 		String: `TernaryParam : Func	<<  >>`,
 		Id:         "TernaryParam",
 		NTType:     13,
-		Index:      37,
+		Index:      38,
 		NumSymbols: 1,
 		ReduceFunc: func(X []Attrib) (Attrib, error) {
 			return X[0], nil


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #152 
**What is the current behavior?**
Does not support this case: `string.equals("sea", "sea") == true` or `isDefined($activity[rest_2].result.photoUrlz) != false`
**What is the new behavior?**
Support expression like: `isDefined($activity[rest_2].result.photoUrlz) != false` or `string.equals("seafood,name", "sea") == false`