### PR TITLE
Logging metadata for activity and trigger

### DIFF
--- a/core/activity/metadata.go
+++ b/core/activity/metadata.go
@@ -9,6 +9,7 @@ import (
 // Metadata is the metadata for the Activity
 type Metadata struct {
 	ID             string
+	Version        string
 	Settings       map[string]*data.Attribute
 	Input          map[string]*data.Attribute
 	Output         map[string]*data.Attribute
@@ -31,8 +32,9 @@ func NewMetadata(jsonMetadata string) *Metadata {
 func (md *Metadata) UnmarshalJSON(b []byte) error {
 
 	ser := &struct {
-		Name string `json:"name"`
-		Ref  string `json:"ref"`
+		Name    string `json:"name"`
+		Version string `json:"version"`
+		Ref     string `json:"ref"`
 
 		Settings  []*data.Attribute `json:"settings"`
 		Input     []*data.Attribute `json:"input"`
@@ -57,6 +59,8 @@ func (md *Metadata) UnmarshalJSON(b []byte) error {
 		// TODO remove and add a proper error once the BC is removed
 		md.ID = ser.Name
 	}
+
+	md.Version = ser.Version
 
 	md.ProducesResult = ser.Reply || ser.Return
 	md.DynamicIO = ser.DynamicIO

--- a/core/activity/registry.go
+++ b/core/activity/registry.go
@@ -21,7 +21,7 @@ func Register(activity Activity) {
 		panic("cannot register 'nil' activity")
 	}
 
-	logger.Debugf("Registering activity: '%s'", activity.Metadata().ID)
+	logger.Debugf("Registering activity [ %s ] which has version [ %s ]", activity.Metadata().ID, activity.Metadata().Version)
 
 	id := activity.Metadata().ID
 

--- a/core/trigger/metadata.go
+++ b/core/trigger/metadata.go
@@ -9,6 +9,7 @@ import (
 // Metadata is the metadata for a Trigger
 type Metadata struct {
 	ID       string
+	Version  string
 	Handler  *HandlerMetadata
 	Settings map[string]*data.Attribute
 	Output   map[string]*data.Attribute
@@ -36,6 +37,7 @@ func (md *Metadata) UnmarshalJSON(b []byte) error {
 
 	ser := &struct {
 		Name     string            `json:"name"`
+		Version  string            `json:"version"`
 		Ref      string            `json:"ref"`
 		Handler  *HandlerMetadata  `json:"handler"`
 		Settings []*data.Attribute `json:"settings"`
@@ -58,6 +60,8 @@ func (md *Metadata) UnmarshalJSON(b []byte) error {
 		// TODO remove and add a proper error once the BC is removed
 		md.ID = ser.Name
 	}
+
+	md.Version = ser.Version
 
 	if ser.Handler != nil {
 		md.Handler = ser.Handler

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -154,7 +154,7 @@ func (e *engineImpl) Start() error {
 	var failed []string
 
 	for key, value := range e.triggers {
-		triggerInfo := &managed.Info{Name:key}
+		triggerInfo := &managed.Info{Name: key}
 		err := managed.Start(fmt.Sprintf("Trigger [ %s ]", key), value)
 		if err != nil {
 			logger.Infof("Trigger [%s] failed to start due to error [%s]", key, err.Error())
@@ -170,6 +170,7 @@ func (e *engineImpl) Start() error {
 		} else {
 			triggerInfo.Status = managed.StatusStarted
 			logger.Infof("Trigger [ %s ]: Started", key)
+			logger.Debugf("Trigger [ %s ] has ref [ %s ] and version [ %s ]", key, value.Metadata().ID, value.Metadata().Version)
 		}
 
 		e.triggerInfos[key] = triggerInfo

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -123,6 +123,7 @@ func (e *engineImpl) Start() error {
 
 	logger.SetDefaultLogger("engine")
 
+	logger.Debugf("Starting app [ %s ] with version [ %s ]", e.app.Name, e.app.Version)
 	logger.Info("Engine Starting...")
 
 	// Todo document RunnerType for engine configuration


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[X] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: # https://github.com/TIBCOSoftware/flogo/issues/216

**What is the current behavior?** The current version doesn't output debug statements of the versions of the triggers and activities

**What is the new behavior?** If the loglevel is set to debug it will print for activities:
```
Registering activity [ github.com/TIBCOSoftware/flogo-contrib/activity/log ] which has version [ 0.0.1 ]
```
and for triggers it will print
```
Trigger [ my_rest_trigger ] has ref [ github.com/TIBCOSoftware/flogo-contrib/trigger/rest ] and version [ 0.0.1 ]
```