### PR TITLE
Adding substring in exprmapper so it can be used

### DIFF
--- a/core/mapper/exprmapper/exprmapper.go
+++ b/core/mapper/exprmapper/exprmapper.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/function/string/equals"
 	_ "github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/function/string/equalsignorecase"
 	_ "github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/function/string/length"
+	_ "github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/function/string/substring"
 )
 
 var log = logger.GetLogger("mapper")


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[X] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```
 _In my original PR (#175) to introduce substring, I didn't add the import into `exprmapper.go`. This PR fixes that and makes the substring available for use by the engine_
