### PR TITLE
Added array length function

### DIFF
--- a/core/mapper/exprmapper/exprmapper.go
+++ b/core/mapper/exprmapper/exprmapper.go
@@ -16,6 +16,7 @@ import (
 	"github.com/TIBCOSoftware/flogo-lib/logger"
 
 	//Pre registry all function for now
+	_ "github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/function/array/length"
 	_ "github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/function/number/random"
 	_ "github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/function/string/concat"
 	_ "github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/function/string/equals"

--- a/core/mapper/exprmapper/function/array/length/length.go
+++ b/core/mapper/exprmapper/function/array/length/length.go
@@ -1,0 +1,33 @@
+package length
+
+import (
+	"github.com/TIBCOSoftware/flogo-lib/core/data"
+	"github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/expression/function"
+	"github.com/TIBCOSoftware/flogo-lib/logger"
+)
+
+var log = logger.GetLogger("length-function")
+
+type Length struct {
+}
+
+func init() {
+	function.Registry(&Length{})
+}
+
+func (s *Length) GetName() string {
+	return "length"
+}
+
+func (s *Length) GetCategory() string {
+	return "array"
+}
+
+func (s *Length) Eval(arr interface{}) int {
+	log.Debugf("Return the length of array \"%v\"", arr)
+	myArr, err := data.CoerceToArray(arr)
+	if err != nil {
+		log.Errorf(err.Error())
+	}
+	return len(myArr)
+}

--- a/core/mapper/exprmapper/function/array/length/length.go
+++ b/core/mapper/exprmapper/function/array/length/length.go
@@ -1,6 +1,8 @@
 package length
 
 import (
+	"fmt"
+
 	"github.com/TIBCOSoftware/flogo-lib/core/data"
 	"github.com/TIBCOSoftware/flogo-lib/core/mapper/exprmapper/expression/function"
 	"github.com/TIBCOSoftware/flogo-lib/logger"
@@ -23,11 +25,11 @@ func (s *Length) GetCategory() string {
 	return "array"
 }
 
-func (s *Length) Eval(arr interface{}) int {
+func (s *Length) Eval(arr interface{}) (int, error) {
 	log.Debugf("Return the length of array \"%v\"", arr)
 	myArr, err := data.CoerceToArray(arr)
 	if err != nil {
-		log.Errorf(err.Error())
+		return 0, fmt.Errorf(err.Error())
 	}
-	return len(myArr)
+	return len(myArr), nil
 }

--- a/core/mapper/exprmapper/function/array/length/length_test.go
+++ b/core/mapper/exprmapper/function/array/length/length_test.go
@@ -1,0 +1,27 @@
+package length
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var s = &Length{}
+
+func TestLength(t *testing.T) {
+	// Length(arr)
+	// arr : input array
+
+	// Should produce "3"
+	arr := []string{"1", "2", "3"}
+	sub := s.Eval(arr)
+	fmt.Printf("Result [%v] should be equal to: 3\n", sub)
+	assert.Equal(t, 3, sub)
+
+	// Should produce "5"
+	arr2 := []int{1, 2, 3, 4, 5}
+	sub = s.Eval(arr2)
+	fmt.Printf("Result [%v] should be equal to: 5\n", sub)
+	assert.Equal(t, 5, sub)
+}

--- a/core/mapper/exprmapper/function/array/length/length_test.go
+++ b/core/mapper/exprmapper/function/array/length/length_test.go
@@ -15,13 +15,18 @@ func TestLength(t *testing.T) {
 
 	// Should produce "3"
 	arr := []string{"1", "2", "3"}
-	sub := s.Eval(arr)
+	sub, _ := s.Eval(arr)
 	fmt.Printf("Result [%v] should be equal to: 3\n", sub)
 	assert.Equal(t, 3, sub)
 
 	// Should produce "5"
 	arr2 := []int{1, 2, 3, 4, 5}
-	sub = s.Eval(arr2)
+	sub, _ = s.Eval(arr2)
 	fmt.Printf("Result [%v] should be equal to: 5\n", sub)
 	assert.Equal(t, 5, sub)
+
+	// Should produce an error
+	arr3 := "Hello!"
+	_, err := s.Eval(arr3)
+	fmt.Printf("Result [%v] should contain: unable to coerce\n", err)
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[X] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: https://github.com/TIBCOSoftware/flogo/issues/282

**What is the current behavior?** You cannot use the length of an array in a function

**What is the new behavior?** This introduces the `array.length()` function which will return the length of an array

```go
// Executing it on this array would produce 3
arr := []string{"1", "2", "3"}

// Executing it on this array produces 5
arr2 := []int{1, 2, 3, 4, 5}
```