### PR TITLE
Remove unnecessary Warn log

### DIFF
--- a/core/mapper/exprmapper/expression/expression.go
+++ b/core/mapper/exprmapper/expression/expression.go
@@ -14,7 +14,6 @@ var log = logger.GetLogger("expression")
 func ParseExpression(exprString string) (expr.Expr, error) {
 	st, err := getParser(exprString)
 	if err != nil {
-		log.Warnf("Error to parser expression, %+v ", err.Error())
 		return nil, err
 	}
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[*] Other... Please describe: Remove a warn log which is unless

```

**Fixes**: #

**What is the current behavior?**
For expression mapping, it always prints warn message if it is not an expression.

**What is the new behavior?**

No, warn log anymore 