### PR TITLE
throw error out/print to console while panic happen in service start

### DIFF
--- a/util/managed/managed.go
+++ b/util/managed/managed.go
@@ -18,19 +18,16 @@ type Managed interface {
 }
 
 // start starts a "Managed" object
-func start(managed Managed) error {
+func start(managed Managed) (err error) {
 
-	defer func() error {
+	defer func() {
 		if r := recover(); r != nil {
-			err, ok := r.(error)
+			var ok bool
+			err, ok = r.(error)
 			if !ok {
 				err = fmt.Errorf("%v", r)
 			}
-
-			return err
 		}
-
-		return nil
 	}()
 
 	return managed.Start()


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
The engine did not print any error to console while panic occurred at service/trigger start
**What is the new behavior?**
Throw the panic recover out