### PR TITLE
Resolving env reference in property value

### DIFF
--- a/core/data/attribute.go
+++ b/core/data/attribute.go
@@ -99,6 +99,19 @@ func (a *Attribute) UnmarshalJSON(data []byte) error {
 	}
 	a.dataType = dt
 
+	strValue, ok := ser.Value.(string)
+	if ok {
+		if strValue != "" && strValue[0] == '$' {
+			// Let resolver resolve value
+			val, err := GetBasicResolver().Resolve(strValue, nil)
+			if err != nil {
+				return err
+			}
+			// Set resolved value
+			ser.Value = val
+		}
+	}
+
 	val, err := CoerceToValue(ser.Value, a.dataType)
 
 	if err != nil {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
For non string type properties, when value is set to env, runtime fails due to type incompatibility as value is not resolved appropriately. 
`
{
  "name": "MAX_COUNT",
  "type": "integer",
  "value": "$env.MAX_COUNT"
}
`
**What is the new behavior?**
Before coercing value, env var is resolved using appropriate resolver.
