### PR TITLE
Ability to override log levels for contributions

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ const (
 	DATA_SECRET_KEY_DEFAULT       = "flogo"
 	ENV_APP_PROPERTY_OVERRIDE_KEY = "FLOGO_APP_PROPS_OVERRIDE"
 	ENV_APP_PROPERTY_RESOLVER_KEY = "FLOGO_APP_PROPS_VALUE_RESOLVER"
+	ENV_LOG_LEVEL_OVERRIDE_KEY    = "FLOGO_CONTRIB_LOG_LEVEL_OVERRIDE"
 )
 
 var defaultLogLevel = LOG_LEVEL_DEFAULT
@@ -90,6 +91,14 @@ func GetAppPropertiesOverride() string {
 
 func GetAppPropertiesValueResolver() string {
 	key := os.Getenv(ENV_APP_PROPERTY_RESOLVER_KEY)
+	if len(key) > 0 {
+		return key
+	}
+	return ""
+}
+
+func GetContribLogLevelOverride() string {
+	key := os.Getenv(ENV_LOG_LEVEL_OVERRIDE_KEY)
 	if len(key) > 0 {
 		return key
 	}

--- a/logger/logfactory.go
+++ b/logger/logfactory.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/TIBCOSoftware/flogo-lib/config"
+	"strings"
 )
 
 var loggerMap = make(map[string]Logger)
+var overrideLogLevelMap = make(map[string]Level)
 var mutex = &sync.RWMutex{}
 var logLevel = InfoLevel
 var logFormat = "TEXT"
@@ -27,6 +29,24 @@ func init() {
 		println("Unsupported Log Level - [" + logLevelName + "]. Set to Log Level - [" + defaultLogLevel + "]")
 	} else {
 		logLevel = getLogLevel
+	}
+
+	// Gather overridden log levels
+	overrideValues := config.GetContribLogLevelOverride()
+	if overrideValues != "" {
+		for _, pair := range strings.Split(overrideValues, ",") {
+			kv := strings.Split(pair, "=")
+			if len(kv) == 2 && kv[0] != "" &&  kv[1] != "" {
+				ll, err := GetLevelForName(kv[1])
+				if err != nil {
+					println("'%s' is not valid override value for '%s'. %s", pair, config.ENV_LOG_LEVEL_OVERRIDE_KEY, err.Error())
+				} else {
+					overrideLogLevelMap[kv[0]] = ll
+				}
+			} else {
+				println("'%s' is not valid override value for '%s'. It must be in PropName=PropValue format.", pair, config.ENV_LOG_LEVEL_OVERRIDE_KEY)
+			}
+		}
 	}
 
 	logFormat = config.GetLogFormat()
@@ -134,15 +154,15 @@ func (l *DefaultLogger) Errorf(format string, args ...interface{}) {
 func (l *DefaultLogger) SetLogLevel(logLevel Level) {
 	switch logLevel {
 	case DebugLevel:
-		l.loggerImpl.Level = logrus.DebugLevel
+		l.loggerImpl.SetLevel(logrus.DebugLevel)
 	case InfoLevel:
-		l.loggerImpl.Level = logrus.InfoLevel
+		l.loggerImpl.SetLevel(logrus.InfoLevel)
 	case ErrorLevel:
-		l.loggerImpl.Level = logrus.ErrorLevel
+		l.loggerImpl.SetLevel(logrus.ErrorLevel)
 	case WarnLevel:
-		l.loggerImpl.Level = logrus.WarnLevel
+		l.loggerImpl.SetLevel(logrus.WarnLevel)
 	default:
-		l.loggerImpl.Level = logrus.ErrorLevel
+		l.loggerImpl.SetLevel(logrus.ErrorLevel)
 	}
 }
 
@@ -150,6 +170,20 @@ func (l *DefaultLogger) GetLogLevel() Level {
 	levelStr := getLevel(l.loggerImpl.Level)
 	level, _ := GetLevelForName(levelStr)
 	return level
+}
+
+func getLogLevel(loggerName string) Level {
+	if len(overrideLogLevelMap) > 0 {
+		// Find overridden log level
+		for name, loglevel := range overrideLogLevelMap {
+			// Look for logger which matches given name
+			if strings.Contains(loggerName, name) {
+				return loglevel
+			}
+		}
+	}
+	// Return engine log level
+	return logLevel
 }
 
 func (logfactory *DefaultLoggerFactory) GetLogger(name string) Logger {
@@ -172,7 +206,7 @@ func (logfactory *DefaultLoggerFactory) GetLogger(name string) Logger {
 			loggerImpl: logImpl,
 		}
 
-		l.SetLogLevel(logLevel)
+		l.SetLogLevel(getLogLevel(name))
 
 		mutex.Lock()
 		loggerMap[name] = l

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -59,7 +59,7 @@ func GetLogger(name string) Logger {
 func GetLevelForName(name string) (Level, error) {
 	levelForName, ok := levelNames[name]
 	if !ok {
-		return 0, fmt.Errorf("unsupported Log Level '%s'", name)
+		return 0, fmt.Errorf("unsupported Log Level '%s'. supported values - [DEBUG ERROR INFO WARN]", name)
 	}
 	return levelForName, nil
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Currently, app developers can not set different log level for contributions. Today, engine log level controls log levels for all contributions. For debug log level, app developers end up seeing unnecessary logs from the engine and other contributions.
**What is the new behavior?**
With this change, developers can set different log level for contributions(activity/trigger) through below environment variable.
`FLOGO_CONTRIB_LOG_LEVEL_OVERRIDE="<CONTRIB_LOGGER_MATCHER>=<LOG_LEVEL>,<CONTRIB_LOGGER_MATCHER>=<LOG_LEVEL>"` 
e.g. To enable debug logs for Rest activity, set FLOGO_CONTRIB_LOG_LEVEL_OVERRIDE="activity-rest=DEBUG"
To enable debug logs for Rest activity and trigger, set FLOGO_CONTRIB_LOG_LEVEL_OVERRIDE="rest=DEBUG"