### PR TITLE
Fix a typo on logger (logs without formatting)

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -156,7 +156,7 @@ func (e *engineImpl) Start() error {
 
 	logger.SetDefaultLogger("engine")
 
-	logger.Info("Starting app [ %s ] with version [ %s ]", e.app.Name, e.app.Version)
+	logger.Infof("Starting app [ %s ] with version [ %s ]", e.app.Name, e.app.Version)
 	logger.Info("Engine Starting...")
 
 	// Todo document RunnerType for engine configuration


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**

When starting an application, output log looks like:

```
2018-10-19 11:22:40.724 INFO   [engine] - Starting app [ %s ] with version [ %s ]app-name0.0.1
2018-10-19 11:22:40.724 INFO   [engine] - Engine Starting...
2018-10-19 11:22:40.728 INFO   [engine] - Starting Services...
2018-10-19 11:22:40.728 INFO   [engine] - Started Services
```

**What is the new behavior?**

When starting an application, output log looks like:

```
2018-10-19 11:22:40.724 INFO   [engine] - Starting app [ app-name ] with version [ 0.0.1 ]
2018-10-19 11:22:40.724 INFO   [engine] - Engine Starting...
2018-10-19 11:22:40.728 INFO   [engine] - Starting Services...
2018-10-19 11:22:40.728 INFO   [engine] - Started Services
```
