### PR TITLE
Handle single and double quotes in field name

### DIFF
--- a/core/mapper/exprmapper/json/field/field.go
+++ b/core/mapper/exprmapper/json/field/field.go
@@ -54,7 +54,7 @@ func (m *MappingField) paserName() error {
 		if nextAfterBracket == '"' || nextAfterBracket == '\'' {
 			//Special charactors
 			m.s.Mode = scanner.ScanIdents
-			return m.handleSpecialField()
+			return m.handleSpecialField(nextAfterBracket)
 		} else {
 			//HandleArray
 			if m.fields == nil || len(m.fields) <= 0 {
@@ -84,13 +84,14 @@ func (m *MappingField) paserName() error {
 	return nil
 }
 
-func (m *MappingField) handleSpecialField() error {
+func (m *MappingField) handleSpecialField(startQutoes int32) error {
 	fieldName := ""
 	run := true
 
 	for run {
 		switch ch := m.s.Scan(); ch {
-		case '"', '\'':
+		case startQutoes:
+			//Check if end with startQutoes]
 			nextAfterQuotes := m.s.Scan()
 			if nextAfterQuotes == ']' {
 				//end specialfield, startover
@@ -98,6 +99,7 @@ func (m *MappingField) handleSpecialField() error {
 				run = false
 				return m.Parser()
 			} else {
+				fieldName = fieldName + string(startQutoes)
 				fieldName = fieldName + m.s.TokenText()
 			}
 		default:
@@ -117,7 +119,7 @@ func (m *MappingField) Parser() error {
 		if nextAfterBracket == '"' || nextAfterBracket == '\'' {
 			//Special charactors
 			m.s.Mode = scanner.ScanIdents
-			return m.handleSpecialField()
+			return m.handleSpecialField(nextAfterBracket)
 		} else {
 			//HandleArray
 			if m.fields == nil || len(m.fields) <= 0 {

--- a/core/mapper/exprmapper/json/field/field_test.go
+++ b/core/mapper/exprmapper/json/field/field_test.go
@@ -62,6 +62,34 @@ func TestGetAllSpecialFields(t *testing.T) {
 	assert.Equal(t, []string{"Object", "Maps3", "dd.cc[0]", "y.x", "d.d", "name"}, res)
 }
 
+func TestApostoph(t *testing.T) {
+	path := `["'apostoph"]`
+	res, err := GetAllspecialFields(path)
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"'apostoph"}, res)
+
+	path = `[''apostoph']`
+	res, err = GetAllspecialFields(path)
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"'apostoph"}, res)
+
+	path = `['"apo"stoph"']`
+	res, err = GetAllspecialFields(path)
+	assert.Nil(t, err)
+	assert.Equal(t, []string{`"apo"stoph"`}, res)
+
+	path = `["apo'"stoph''"]`
+	res, err = GetAllspecialFields(path)
+	assert.Nil(t, err)
+	assert.Equal(t, []string{`apo'"stoph''`}, res)
+
+	path = "[\"apo`stoph\"]"
+	res, err = GetAllspecialFields(path)
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"apo`stoph"}, res)
+
+}
+
 func TestGetAllSpecialFields2(t *testing.T) {
 	path := `ReceiveSQSMessage.["x.y"][0]["name&name"]`
 	res, err := GetAllspecialFields(path)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Have an issue to support field name has double or single quotes. such as: `'apostoph`
**What is the new behavior?**
Make sure parser has the ability to handle this case.