### PR TITLE
Value resolver to return bool instead error to indicate whether value is resolved or not

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -146,16 +146,18 @@ func GetProperties(properties []*data.Attribute) (map[string]interface{}, error)
 				return props, err
 			}
 
-			strVal, _ := value.(string)
-			if len(strVal) > 0 && strings.HasPrefix(strVal, "SECRET:") {
-				// Resolve secret value
-				newVal, err := resolveSecretValue(strVal)
-				if err != nil {
-					return nil, err
+			if property.Type() == data.TypeString {
+				strVal := value.(string)
+				if strings.HasPrefix(strVal, "SECRET:") {
+					// Resolve secret value
+					newVal, err := resolveSecretValue(value.(string))
+					if err != nil {
+						return nil, err
+					}
+					props[property.Name()] = newVal
+				} else {
+					props[property.Name()] = value
 				}
-				props[property.Name()] = newVal
-			} else {
-				props[property.Name()] = value
 			}
 		}
 		return props, nil

--- a/app/config.go
+++ b/app/config.go
@@ -196,10 +196,9 @@ func loadExternalProperties(properties []*data.Attribute) (map[string]interface{
 	}
 
 	resolverType := config.GetAppPropertiesValueResolver()
-	var resolver PropertyValueResolver
 	if resolverType != "" {
 		logger.Infof("'%s' is set to '%s'. ", config.ENV_APP_PROPERTY_RESOLVER_KEY, resolverType)
-		resolver = GetPropertyValueResolver(resolverType)
+		resolver := GetPropertyValueResolver(resolverType)
 		if resolver == nil {
 			errMag := fmt.Sprintf("Unsupported resolver type - %s. Resolver not registered.", resolverType)
 			return nil, errors.New(errMag)

--- a/app/config.go
+++ b/app/config.go
@@ -146,18 +146,16 @@ func GetProperties(properties []*data.Attribute) (map[string]interface{}, error)
 				return props, err
 			}
 
-			if property.Type() == data.TypeString {
-				strVal := value.(string)
-				if strings.HasPrefix(strVal, "SECRET:") {
-					// Resolve secret value
-					newVal, err := resolveSecretValue(value.(string))
-					if err != nil {
-						return nil, err
-					}
-					props[property.Name()] = newVal
-				} else {
-					props[property.Name()] = value
+			strVal, ok := value.(string)
+			if ok && strings.HasPrefix(strVal, "SECRET:") {
+				// Resolve secret value
+				newVal, err := resolveSecretValue(value.(string))
+				if err != nil {
+					return nil, err
 				}
+				props[property.Name()] = newVal
+			} else {
+				props[property.Name()] = value
 			}
 		}
 		return props, nil

--- a/app/config.go
+++ b/app/config.go
@@ -204,9 +204,7 @@ func loadExternalProperties(properties []*data.Attribute) (map[string]interface{
 			errMag := fmt.Sprintf("Unsupported resolver type - %s. Resolver not registered.", resolverType)
 			return nil, errors.New(errMag)
 		}
-	}
 
-	if resolverType != "" {
 		if len(props) > 0 {
 			// Get value using overridden property name
 			for k, v := range props {
@@ -215,10 +213,10 @@ func loadExternalProperties(properties []*data.Attribute) (map[string]interface{
 					if len(strVal) > 0 && strVal[0] == '$' {
 						// Use resolver
 						newVal, found := resolver.LookupValue(strVal[1:])
-						if !found {
-							logger.Warnf("Property '%s' could not be resolved using resolver '%s'. Using default value.", strVal[1:], resolverType)
-						} else {
+						if found {
 							props[k] = newVal
+						} else {
+							logger.Warnf("Property '%s' could not be resolved using resolver '%s'. Using default value.", strVal[1:], resolverType)
 						}
 					}
 				} else {
@@ -238,6 +236,7 @@ func loadExternalProperties(properties []*data.Attribute) (map[string]interface{
 			}
 		}
 	}
+
 	return props, nil
 }
 

--- a/app/config.go
+++ b/app/config.go
@@ -214,7 +214,7 @@ func loadExternalProperties(properties []*data.Attribute) (map[string]interface{
 				if ok {
 					if len(strVal) > 0 && strVal[0] == '$' {
 						// Use resolver
-						newVal, found := resolver.ResolveValue(strVal[1:])
+						newVal, found := resolver.LookupValue(strVal[1:])
 						if !found {
 							logger.Warnf("Property '%s' could not be resolved using resolver '%s'. Using default value.", strVal[1:], resolverType)
 						} else {
@@ -228,7 +228,7 @@ func loadExternalProperties(properties []*data.Attribute) (map[string]interface{
 		} else {
 			// Resolver is set. Get values using app prop name
 			for _, prop := range properties {
-				newVal, found := resolver.ResolveValue(prop.Name())
+				newVal, found := resolver.LookupValue(prop.Name())
 				if found {
 					// Use new value
 					props[prop.Name()] = newVal

--- a/app/property.go
+++ b/app/property.go
@@ -42,12 +42,8 @@ type EnvVariableValueResolver struct {
 	
 }
 
-func (resolver *EnvVariableValueResolver) ResolveValue(toResolve string) (interface{}, error) {
-	value, exists := os.LookupEnv(toResolve)
-	if !exists {
-		return nil, errors.New(fmt.Sprintf("Environment variable - %s is not set",toResolve))
-	}
-	return value, nil
+func (resolver *EnvVariableValueResolver) ResolveValue(toResolve string) (interface{}, bool) {
+	return os.LookupEnv(toResolve)
 }
 
 
@@ -59,8 +55,10 @@ type PropertyProvider struct {
 	properties map[string]interface{}
 }
 
+// PropertyValueResolver used to resolve value from external configuration like env, file etc
 type PropertyValueResolver interface {
-	ResolveValue(toResolve string) (interface{}, error)
+	// Should return value and true if the given key exists in the external configuration otherwise nil and false.
+	ResolveValue(key string) (interface{}, bool)
 }
 
 func (pp *PropertyProvider) GetProperty(property string) (interface{}, bool) {

--- a/app/property.go
+++ b/app/property.go
@@ -42,7 +42,7 @@ type EnvVariableValueResolver struct {
 	
 }
 
-func (resolver *EnvVariableValueResolver) ResolveValue(toResolve string) (interface{}, bool) {
+func (resolver *EnvVariableValueResolver) LookupValue(toResolve string) (interface{}, bool) {
 	return os.LookupEnv(toResolve)
 }
 
@@ -57,8 +57,8 @@ type PropertyProvider struct {
 
 // PropertyValueResolver used to resolve value from external configuration like env, file etc
 type PropertyValueResolver interface {
-	// Should return value and true if the given key exists in the external configuration otherwise nil and false.
-	ResolveValue(key string) (interface{}, bool)
+	// Should return value and true if the given key exists in the external configuration otherwise should return nil and false.
+	LookupValue(key string) (interface{}, bool)
 }
 
 func (pp *PropertyProvider) GetProperty(property string) (interface{}, bool) {

--- a/app/property_test.go
+++ b/app/property_test.go
@@ -17,7 +17,7 @@ func TestEnvValueResolver(t *testing.T) {
 
 	resolver := GetPropertyValueResolver("env")
 	assert.NotNil(t, resolver)
-	resolvedVal, err := resolver.ResolveValue("TEST_PROP")
-	assert.Nil(t, err)
+	resolvedVal, found := resolver.ResolveValue("TEST_PROP")
+	assert.True(t, true, found)
 	assert.Equal(t, "testprop", resolvedVal)
 }

--- a/app/property_test.go
+++ b/app/property_test.go
@@ -20,4 +20,7 @@ func TestEnvValueResolver(t *testing.T) {
 	resolvedVal, found := resolver.LookupValue("TEST_PROP")
 	assert.True(t, true, found)
 	assert.Equal(t, "testprop", resolvedVal)
+
+	_, found = resolver.LookupValue("TEST_PROP1")
+	assert.False(t, false, found)
 }

--- a/app/property_test.go
+++ b/app/property_test.go
@@ -17,7 +17,7 @@ func TestEnvValueResolver(t *testing.T) {
 
 	resolver := GetPropertyValueResolver("env")
 	assert.NotNil(t, resolver)
-	resolvedVal, found := resolver.ResolveValue("TEST_PROP")
+	resolvedVal, found := resolver.LookupValue("TEST_PROP")
 	assert.True(t, true, found)
 	assert.Equal(t, "testprop", resolvedVal)
 }


### PR DESCRIPTION


**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Value resolver returns error. To follow semantics like os.Lookup() where value is return with bool flag to indicate whether value is indeed found or not.
This change also includes lookup based on app property name.

**What is the new behavior?**
Makes it consistent with Go semantics. Also, makes it easy for developers to resolve app prop value using app prop name.