### PR TITLE
Chaining of resolvers

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -2,16 +2,14 @@ package app
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"os"
 
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"regexp"
 	"strings"
-
-
 
 	"github.com/TIBCOSoftware/flogo-lib/app/resource"
 	"github.com/TIBCOSoftware/flogo-lib/config"
@@ -21,7 +19,6 @@ import (
 	"github.com/TIBCOSoftware/flogo-lib/logger"
 
 	"github.com/TIBCOSoftware/flogo-lib/util"
-
 )
 
 // Config is the configuration for the App
@@ -196,43 +193,41 @@ func loadExternalProperties(properties []*data.Attribute) (map[string]interface{
 		}
 	}
 
+	if len(props) > 0 {
+		// Get value using overridden property name
+		for k, v := range props {
+			props[k] = v
+		}
+	}
 	resolverType := config.GetAppPropertiesValueResolver()
 	if resolverType != "" {
 		logger.Infof("'%s' is set to '%s'. ", config.ENV_APP_PROPERTY_RESOLVER_KEY, resolverType)
-		resolver := GetPropertyValueResolver(resolverType)
-		if resolver == nil {
-			errMag := fmt.Sprintf("Unsupported resolver type - %s. Resolver not registered.", resolverType)
-			return nil, errors.New(errMag)
+
+		var resolvers []PropertyValueResolver
+		for _, resName := range strings.Split(resolverType, ",") {
+			resolver := GetPropertyValueResolver(resName)
+			if resolver == nil {
+				errMag := fmt.Sprintf("Unsupported resolver type - %s. Resolver not registered.", resolverType)
+				return nil, errors.New(errMag)
+			}
+			resolvers = append(resolvers, resolver)
 		}
 
-		if len(props) > 0 {
-			// Get value using overridden property name
-			for k, v := range props {
-				strVal, ok := v.(string)
-				if ok {
-					if len(strVal) > 0 && strVal[0] == '$' {
-						// Use resolver
-						newVal, found := resolver.LookupValue(strVal[1:])
-						if found {
-							props[k] = newVal
-						} else {
-							logger.Warnf("Property '%s' could not be resolved using resolver '%s'. Using default value.", strVal[1:], resolverType)
-						}
-					}
-				} else {
-					props[k] = v
+		// Resolver is set. Get values using app prop name
+		for i, _ := range properties {
+			propName := properties[i].Name()
+			found := false
+			for i, _ := range resolvers {
+				// Use resolver
+				newVal, resolved := resolvers[i].LookupValue(propName)
+				if resolved {
+					props[propName] = newVal
+					found = true
+					break
 				}
 			}
-		} else {
-			// Resolver is set. Get values using app prop name
-			for _, prop := range properties {
-				newVal, found := resolver.LookupValue(prop.Name())
-				if found {
-					// Use new value
-					props[prop.Name()] = newVal
-				} else {
-					logger.Warnf("Property - '%s' could not be resolved using resolver - '%s'. Using default value.", prop.Name(), resolverType)
-				}
+			if !found {
+				logger.Warnf("Property '%s' could not be resolved using resolver(s) '%s'. Using default value.", propName, resolverType)
 			}
 		}
 	}

--- a/app/config.go
+++ b/app/config.go
@@ -193,12 +193,6 @@ func loadExternalProperties(properties []*data.Attribute) (map[string]interface{
 		}
 	}
 
-	if len(props) > 0 {
-		// Get value using overridden property name
-		for k, v := range props {
-			props[k] = v
-		}
-	}
 	resolverType := config.GetAppPropertiesValueResolver()
 	if resolverType != "" {
 		logger.Infof("'%s' is set to '%s'. ", config.ENV_APP_PROPERTY_RESOLVER_KEY, resolverType)

--- a/app/property_test.go
+++ b/app/property_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"os"
 	"github.com/TIBCOSoftware/flogo-lib/config"
+	"github.com/TIBCOSoftware/flogo-lib/core/data"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,4 +24,20 @@ func TestEnvValueResolver(t *testing.T) {
 
 	_, found = resolver.LookupValue("TEST_PROP1")
 	assert.False(t, false, found)
+}
+
+func TestExternalPropResolution(t *testing.T) {
+	os.Setenv(config.ENV_APP_PROPERTY_RESOLVER_KEY, "env")
+	os.Setenv("MyProp", "env_myprop_value")
+	defer func() {
+		os.Unsetenv(config.ENV_APP_PROPERTY_RESOLVER_KEY)
+		os.Unsetenv("MyProp")
+	}()
+
+	var attrs []*data.Attribute
+	attr, _ := data.NewAttribute("MyProp", data.TypeString, "")
+	attrs = append(attrs, attr)
+	resolvedProps, err := loadExternalProperties(attrs)
+	assert.Nil(t, err)
+	assert.Equal(t, "env_myprop_value", resolvedProps["MyProp"])
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Currently, users can not chain property resolvers e.g. FLOGO_APP_PROPS_RESOLVERS=env,json,consul
**What is the new behavior?**
App property resolution mechanism now supports comma separated list of resolvers. Now runtime will attempt to resolve app property using all configured resolvers.